### PR TITLE
Use a ratio to split train vs val set in tools/vqgan/create_train_split.py

### DIFF
--- a/tools/vqgan/create_train_split.py
+++ b/tools/vqgan/create_train_split.py
@@ -10,7 +10,9 @@ from fish_speech.utils.file import AUDIO_EXTENSIONS, list_files
 
 @click.command()
 @click.argument("root", type=click.Path(exists=True, path_type=Path))
-def main(root):
+@click.option("val_ratio", type=float, default=0.2)
+@click.option("val_count", type=int, default=None)
+def main(root, val_ratio, val_count):
     files = list_files(root, AUDIO_EXTENSIONS, recursive=True)
     print(f"Found {len(files)} files")
 
@@ -21,10 +23,10 @@ def main(root):
     # use 3:1 ratio on train vs val
     val_size = math.ceil(len(files) / 4)  # at least one val file
 
-    with open(root / "vq_train_filelist.txt", "w") as f:
+    with open(root / "vq_train_filelist.txt", "w", encoding="utf-8") as f:
         f.write("\n".join(files[val_size:]))
 
-    with open(root / "vq_val_filelist.txt", "w") as f:
+    with open(root / "vq_val_filelist.txt", "w", encoding="utf-8") as f:
         f.write("\n".join(files[:val_size]))
 
     print("Done")

--- a/tools/vqgan/create_train_split.py
+++ b/tools/vqgan/create_train_split.py
@@ -10,8 +10,8 @@ from fish_speech.utils.file import AUDIO_EXTENSIONS, list_files
 
 @click.command()
 @click.argument("root", type=click.Path(exists=True, path_type=Path))
-@click.option("val_ratio", type=float, default=0.2)
-@click.option("val_count", type=int, default=None)
+@click.option("--val-ratio", type=float, default=0.2)
+@click.option("--val-count", type=int, default=None)
 def main(root, val_ratio, val_count):
     files = list_files(root, AUDIO_EXTENSIONS, recursive=True)
     print(f"Found {len(files)} files")

--- a/tools/vqgan/create_train_split.py
+++ b/tools/vqgan/create_train_split.py
@@ -1,5 +1,4 @@
 import math
-
 from pathlib import Path
 from random import Random
 
@@ -20,7 +19,7 @@ def main(root):
     Random(42).shuffle(files)
 
     # use 3:1 ratio on train vs val
-    val_size = math.ceil(len(files) / 4) # at least one val file
+    val_size = math.ceil(len(files) / 4)  # at least one val file
 
     with open(root / "vq_train_filelist.txt", "w") as f:
         f.write("\n".join(files[val_size:]))

--- a/tools/vqgan/create_train_split.py
+++ b/tools/vqgan/create_train_split.py
@@ -23,8 +23,7 @@ def main(root, val_ratio, val_count):
     if val_count is not None:
         if val_count < 1 or val_count > len(files):
             raise ValueError("val_count must be between 1 and number of files")
-        else:
-            val_size = val_count
+        val_size = val_count
     else:
         val_size = math.ceil(len(files) * val_ratio)
 

--- a/tools/vqgan/create_train_split.py
+++ b/tools/vqgan/create_train_split.py
@@ -1,3 +1,5 @@
+import math
+
 from pathlib import Path
 from random import Random
 
@@ -17,11 +19,14 @@ def main(root):
 
     Random(42).shuffle(files)
 
+    # use 3:1 ratio on train vs val
+    val_size = math.ceil(len(files) / 4) # at least one val file
+
     with open(root / "vq_train_filelist.txt", "w") as f:
-        f.write("\n".join(files[:-100]))
+        f.write("\n".join(files[val_size:]))
 
     with open(root / "vq_val_filelist.txt", "w") as f:
-        f.write("\n".join(files[-100:]))
+        f.write("\n".join(files[:val_size]))
 
     print("Done")
 

--- a/tools/vqgan/create_train_split.py
+++ b/tools/vqgan/create_train_split.py
@@ -20,8 +20,13 @@ def main(root, val_ratio, val_count):
 
     Random(42).shuffle(files)
 
-    # use 3:1 ratio on train vs val
-    val_size = math.ceil(len(files) / 4)  # at least one val file
+    if val_count is not None:
+        if val_count < 1 or val_count > len(files):
+            raise ValueError("val_count must be between 1 and number of files")
+        else:
+            val_size = val_count
+    else:
+        val_size = math.ceil(len(files) * val_ratio)
 
     with open(root / "vq_train_filelist.txt", "w", encoding="utf-8") as f:
         f.write("\n".join(files[val_size:]))


### PR DESCRIPTION
Currently `tools/vqgan/create_train_split.py` uses a hardcoded 100 samples of val set to split train vs val set.

This will cause an issue for dataset <= 100 samples, and perform badly for dataset <= 200 samples.

This pr changed the split to a ratio of 3:1 (3 training samples vs 1 validation sample), and will hopefully fix this problem.