### PR TITLE
Rerun build only if proto file chaged

### DIFF
--- a/data_server/build.rs
+++ b/data_server/build.rs
@@ -1,4 +1,9 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../fish_speech/datasets/protos/text-data.proto")?;
+    const TEXT_DATA_PROTO: &str = "../fish_speech/datasets/protos/text-data.proto";
+
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed={}", TEXT_DATA_PROTO);
+
+    tonic_build::compile_protos(TEXT_DATA_PROTO)?;
     Ok(())
 }


### PR DESCRIPTION
> it is recommended that every build script emit at least one of the rerun-if instructions

see: https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection