### PR TITLE
The decimal point will be split into two sentences, will be cut off from the middle.

### DIFF
--- a/tools/llama/generate.py
+++ b/tools/llama/generate.py
@@ -425,24 +425,25 @@ def split_text(text, min_length):
         curr = curr.strip()
         if curr and not all(c.isspace() or c in string.punctuation for c in curr):
             segments.append(curr)
+
     def is_float(value):
         try:
             float(value)
             return True
         except ValueError:
             return False
-    for index,char in enumerate(text):
+
+    for index, char in enumerate(text):
         curr += char
         if char not in [".", "!", "?"]:
             continue
-        if len(curr) >= min_length and not is_float(text[index-1:index+2]):
+        if len(curr) >= min_length and not is_float(text[index - 1 : index + 2]):
             clean_add(curr)
             curr = ""
 
     clean_add(curr)
 
     return segments
-
 
 
 @dataclass

--- a/tools/llama/generate.py
+++ b/tools/llama/generate.py
@@ -425,19 +425,24 @@ def split_text(text, min_length):
         curr = curr.strip()
         if curr and not all(c.isspace() or c in string.punctuation for c in curr):
             segments.append(curr)
-
-    for char in text:
+    def is_float(value):
+        try:
+            float(value)
+            return True
+        except ValueError:
+            return False
+    for index,char in enumerate(text):
         curr += char
         if char not in [".", "!", "?"]:
             continue
-
-        if len(curr) >= min_length:
+        if len(curr) >= min_length and not is_float(text[index-1:index+2]):
             clean_add(curr)
             curr = ""
 
     clean_add(curr)
 
     return segments
+
 
 
 @dataclass


### PR DESCRIPTION
for example "据海关统计，今年前4个月，我国货物贸易进出口总值13.81万亿元，同比增长5.7%， 其中，出口7.81万亿元，增长4.9%，进口6万亿元，增长6.8%。"

**Is this PR adding new feature or fix a BUG?**

Add feature / Fix BUG.

**Is this pull request related to any issue? If yes, please link the issue.**

#xxx
