### PR TITLE
默认关闭cudnn benchmark

### DIFF
--- a/fish_speech/configs/vits_decoder_finetune.yaml
+++ b/fish_speech/configs/vits_decoder_finetune.yaml
@@ -15,6 +15,7 @@ trainer:
   precision: 32
   max_steps: 100_000
   val_check_interval: 100
+  benchmark: true
 
 sample_rate: 44100
 hop_length: 512

--- a/fish_speech/configs/vits_decoder_finetune.yaml
+++ b/fish_speech/configs/vits_decoder_finetune.yaml
@@ -15,7 +15,7 @@ trainer:
   precision: 32
   max_steps: 100_000
   val_check_interval: 100
-  benchmark: true
+  benchmark: false
 
 sample_rate: 44100
 hop_length: 512

--- a/fish_speech/configs/vits_decoder_pretrain.yaml
+++ b/fish_speech/configs/vits_decoder_pretrain.yaml
@@ -14,6 +14,7 @@ trainer:
   precision: 32
   max_steps: 1_000_000
   val_check_interval: 1000
+  benchmark: false
 
 sample_rate: 44100
 hop_length: 512


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.
在部分Ampere GPU上，开启此选项会导致异常的速度损失（>90%）和GPU Memory占用波动。因此默认关闭