### PR TITLE
Fix português (brasil) README.md path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**English** | [中文简体](README.zh.md) | [Portuguese (Brazil)](README.pt-BR)
+**English** | [中文简体](README.zh.md) | [Portuguese (Brazil)](README.pt-BR.md)
 
 </div>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[English](README.md) | **中文简体** | [Português (Brasil)](README.pt-BR)
+[English](README.md) | **中文简体** | [Português (Brasil)](README.pt-BR.md)
 
 </div>
 


### PR DESCRIPTION
This pull request is a fix for the Portuguese readme.md path, which is incorrect.

Someone put README.pt-BR instead of README.pt-BR.md in the README.md and README.zh.md documents.