### PR TITLE
 Fix Import Path in tools/vqgan/inference.py

### DIFF
--- a/tools/vqgan/inference.py
+++ b/tools/vqgan/inference.py
@@ -11,7 +11,7 @@ from hydra.utils import instantiate
 from loguru import logger
 from omegaconf import OmegaConf
 
-from fish_speech.utils.file import AUDIO_EXTENSIONS
+from tools.file import AUDIO_EXTENSIONS
 
 # register eval resolver
 OmegaConf.register_new_resolver("eval", eval)


### PR DESCRIPTION
This pull request addresses an issue in tools/vqgan/inference.py where the import statement for AUDIO_EXTENSIONS was incorrect. The import statement was originally:

```python
from fish_speech.utils.file import AUDIO_EXTENSIONS
```

It has been updated to:
```python
from tools.file import AUDIO_EXTENSIONS
```