### PR TITLE
Avoid cuda-dependent code for CPU-only inference

### DIFF
--- a/tools/llama/generate.py
+++ b/tools/llama/generate.py
@@ -5,6 +5,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Optional, Tuple, Union
+from contextlib import nullcontext
 
 import click
 import hydra
@@ -183,7 +184,7 @@ def decode_n_tokens(
 
         with torch.backends.cuda.sdp_kernel(
             enable_flash=False, enable_mem_efficient=False, enable_math=True
-        ):  # Actually better for Inductor to codegen attention here
+        ) if torch.cuda.is_available() else nullcontext():  # Actually better for Inductor to codegen attention here
             next_token = decode_one_token(
                 model=model,
                 x=cur_token,

--- a/tools/llama/generate.py
+++ b/tools/llama/generate.py
@@ -2,10 +2,10 @@ import os
 import queue
 import threading
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Optional, Tuple, Union
-from contextlib import nullcontext
 
 import click
 import hydra
@@ -182,9 +182,13 @@ def decode_n_tokens(
         else:
             window = previous_tokens[:, i - win_size : i]
 
-        with torch.backends.cuda.sdp_kernel(
-            enable_flash=False, enable_mem_efficient=False, enable_math=True
-        ) if torch.cuda.is_available() else nullcontext():  # Actually better for Inductor to codegen attention here
+        with (
+            torch.backends.cuda.sdp_kernel(
+                enable_flash=False, enable_mem_efficient=False, enable_math=True
+            )
+            if torch.cuda.is_available()
+            else nullcontext()
+        ):  # Actually better for Inductor to codegen attention here
             next_token = decode_one_token(
                 model=model,
                 x=cur_token,


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.

When running inference on CPU (I'm running this on M1 Pro Macbook), installed torch may lack compiled-in cuda support altogether, resulting in `module 'torch.backends' has no attribute 'sdp_kernel'` error. `--device cpu` command line flag correctly deals with all situation except this one, so check here for cuda availability explicitly.