### PR TITLE
Fix reference to load_filelist

### DIFF
--- a/tools/llama/build_dataset.py
+++ b/tools/llama/build_dataset.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 from fish_speech.datasets.protos.text_data_pb2 import Semantics, Sentence, TextData
 from fish_speech.datasets.protos.text_data_stream import pack_pb_stream
-from fish_speech.utils.file import load_filelist
+from tools.file import load_filelist
 
 # To avoid CPU overload
 os.environ["MKL_NUM_THREADS"] = "1"


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.

**Is this pull request related to any issue?**

No

Corrects an invalid reference after the function `load_filelist` was moved to `tools.file`, resolving runtime errors.
