### PR TITLE
Fix BUG pytorch dependency resolver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 
 [project.optional-dependencies]
 stable = [
-    "torch==2.3.1",
+    "torch>=2.3.1",
     "torchaudio",
 ]
 


### PR DESCRIPTION
following the install step,  install pytorch first ,then the dependency of project. pytorch will reinstalled if the version isn't 2.3.1. 
it will also trick a bug by dependency resolver. 

```
 Attempting uninstall: triton
    Found existing installation: triton 3.0.0
    Uninstalling triton-3.0.0:
      Successfully uninstalled triton-3.0.0
  Attempting uninstall: nvidia-cudnn-cu12
    Found existing installation: nvidia-cudnn-cu12 9.1.0.70
    Uninstalling nvidia-cudnn-cu12-9.1.0.70:
      Successfully uninstalled nvidia-cudnn-cu12-9.1.0.70
  Attempting uninstall: numpy
    Found existing installation: numpy 2.1.1
    Uninstalling numpy-2.1.1:
      Successfully uninstalled numpy-2.1.1
  Attempting uninstall: fsspec
    Found existing installation: fsspec 2024.9.0
    Uninstalling fsspec-2024.9.0:
      Successfully uninstalled fsspec-2024.9.0
  Attempting uninstall: torch
    Found existing installation: torch 2.4.1
    Uninstalling torch-2.4.1:
      Successfully uninstalled torch-2.4.1
  Attempting uninstall: torchaudio
    Found existing installation: torchaudio 2.4.1
    Uninstalling torchaudio-2.4.1:
      Successfully uninstalled torchaudio-2.4.1
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
torchvision 0.19.1 requires torch==2.4.1, but you have torch 2.3.1 which is incompatible.
```