### PR TITLE
Fix: Docker icon is missing in zh-cn README & ja README displays that it is in English & properer expression “简体中文”

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[英語](README.md) | [中文简体](README.zh.md) | [ポルトガル語 (ブラジル)](README.pt-BR.md) | **日本語**
+[英語](README.md) | [中国語](README.zh.md) | [ポルトガル語 (ブラジル)](README.pt-BR.md) | **日本語**
 
 </div>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,13 +1,9 @@
 # Fish Speech
 
-**英語** | [中文简体](README.zh.md) | [ポルトガル語 (ブラジル)](README.pt-BR.md) | 日本語
+<div align="center">
 
-<div>
-<a href="https://www.producthunt.com/posts/fish-speech-1-4?embed=true&utm_source=badge-featured&utm_medium=badge&utm_souce=badge-fish&#0045;speech&#0045;1&#0045;4" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=488440&theme=light" alt="Fish&#0032;Speech&#0032;1&#0046;4 - Open&#0045;Source&#0032;Multilingual&#0032;Text&#0045;to&#0045;Speech&#0032;with&#0032;Voice&#0032;Cloning | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+[英語](README.md) | [中文简体](README.zh.md) | [ポルトガル語 (ブラジル)](README.pt-BR.md) | **日本語**
 
-<a href="https://trendshift.io/repositories/7014" target="_blank">
-<img src="https://trendshift.io/api/badge/repositories/7014" alt="fishaudio%2Ffish-speech | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
-</a>
 </div>
 
 <div>
@@ -38,6 +34,8 @@
 #### V1.4 デモビデオ: https://www.bilibili.com/video/BV1pu46eVEk7
 
 #### V1.2 デモビデオ: https://www.bilibili.com/video/BV1wz421B71D
+
+#### V1.1 デモビデオ: https://www.bilibili.com/video/BV1zJ4m1K7cj
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Fish Speech
 
-**English** | [中文简体](README.zh.md) | [Portuguese (Brazil)](README.pt-BR.md)| [日本語](README.ja.md)
+<div align="center">
+
+**English** | [简体中文](README.zh.md) | [Portuguese (Brazil)](README.pt-BR.md)| [日本語](README.ja.md)
+
+</div>
 
 <div>
 <a href="https://www.producthunt.com/posts/fish-speech-1-4?embed=true&utm_source=badge-featured&utm_medium=badge&utm_souce=badge-fish&#0045;speech&#0045;1&#0045;4" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=488440&theme=light" alt="Fish&#0032;Speech&#0032;1&#0046;4 - Open&#0045;Source&#0032;Multilingual&#0032;Text&#0045;to&#0045;Speech&#0032;with&#0032;Voice&#0032;Cloning | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[English](README.md) | **中文简体** | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md)
+[English](README.md) | **简体中文** | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md)
 
 </div>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,7 +14,7 @@
 <img alt="QQ" src="https://img.shields.io/badge/QQ Group-%2312B7F5?logo=tencent-qq&logoColor=white&style=flat-square"/>
 </a>
 <a target="_blank" href="https://hub.docker.com/r/fishaudio/fish-speech">
-<img alt="Docker" src="https://img.sh.io/docker/pulls/fishaudio/fish-speech?style=flat-square&logo=docker"/>
+<img alt="Docker" src="https://img.shields.io/docker/pulls/fishaudio/fish-speech?style=flat-square&logo=docker"/>
 </a>
 </div>
 


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.

**Is this pull request related to any issue? If yes, please link the issue.**

No

1. The src of docker icon is wrong.
<img width="301" alt="1" src="https://github.com/user-attachments/assets/f561d383-2b31-4217-981d-819216694837">

2. jp README shows the file is in English, and it should be center-aligned.
<img width="431" alt="2" src="https://github.com/user-attachments/assets/e29822d4-c645-42f6-9c81-fc3ad9a01612">

3. "中文简体" is wrong in Simplified Chinese expression, the properer one is "简体中文“