### PR TITLE
"Speak" gets prepended to every single utterance.

### DIFF
--- a/tools/llama/generate.py
+++ b/tools/llama/generate.py
@@ -602,7 +602,7 @@ def encode_tokens(
     num_codebooks=4,
 ):
     string = clean_text(string)
-    string = f"<|im_start|>user\nSpeak: {string}<|im_end|><|im_start|>assistant\n"
+    string = f"<|im_start|>user\n{string}<|im_end|><|im_start|>assistant\n"
 
     new_tokens = tokenizer.encode(
         string,


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.

Currently when you try to clone a voice to do TTS, every sentence starts with "Speak" because this gets prepended when passing to the model. Getting rid of this token makes them all work.

To give you an idea of how bad this is, here's an example generated audio clip in Japanese (Same thing happens in other languages as well, such as Korean):


https://github.com/user-attachments/assets/d54b554f-4d13-421d-983e-56653c71b396



```
とつぜん の キス や あつい まなざし で
こい の プログラム を くるわせないで ね
であい と わかれ じょうず に うちこんで
じかん が くれ ば おわる Don’t hurry!

あい に きずついた あの ひ から ずっと
ひる と よる が ぎゃく の くらし を つづけて
はやり のDisco で おどりあかす うち に
おぼえた まじゅつ な の よ I ‘m sorry!
```