### PR TITLE
Fix original shape matching with crop

### DIFF
--- a/fish_speech/models/vqgan/modules/fsq.py
+++ b/fish_speech/models/vqgan/modules/fsq.py
@@ -99,7 +99,7 @@ class DownsampleFiniteScalarQuantize(nn.Module):
         if diff > 0:
             result.z = F.pad(result.z, (left, right))
         elif diff < 0:
-            result.z = result.z[..., left:-right]
+            result.z = result.z[..., -left:right]
 
         return result
 


### PR DESCRIPTION
Let's say `diff=-3` which is negative, then we got `left = diff // 2 =  -2` and `right = diff - left = -1`.

The correct cropping operation should be `result.z[..., 2:-1]` instead of `result.z[..., -2:1]`

