### PR TITLE
fix: Install cachetools dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
 stable = [
     "torch<=2.4.1",
     "torchaudio",
+    "cachetools",
 ]
 
 [build-system]


### PR DESCRIPTION
fix: https://github.com/fishaudio/fish-speech/issues/660

When running the docker image ```ModuleNotFoundError: No module named 'cachetools' ```will appear. Therefore, add the cachetools package to the stable dependency group.