### PR TITLE
fix CPU use

### DIFF
--- a/tools/api.py
+++ b/tools/api.py
@@ -871,6 +871,11 @@ def initialize_app(app: Kui):
     args = parse_args()  # args same as ones in other processes
     args.precision = torch.half if args.half else torch.bfloat16
 
+    # Check if CUDA is available
+    if not torch.cuda.is_available():
+        logger.info("CUDA is not available, running on CPU.")
+        args.device = "cpu"
+
     if args.load_asr_model:
         logger.info(f"Loading ASR model...")
         asr_model = load_asr_model(device=args.device)

--- a/tools/webui.py
+++ b/tools/webui.py
@@ -510,6 +510,11 @@ if __name__ == "__main__":
     args = parse_args()
     args.precision = torch.half if args.half else torch.bfloat16
 
+    # Check if CUDA is available
+    if not torch.cuda.is_available():
+        logger.info("CUDA is not available, running on CPU.")
+        args.device = "cpu"
+
     logger.info("Loading Llama model...")
     llama_queue = launch_thread_safe_queue(
         checkpoint_path=args.llama_checkpoint_path,


### PR DESCRIPTION
Fix for #691 

The argument parsers of the webui and the postapi default `device` to `cuda` but never checks if CUDA is actually available.

This is a very small fix to default to CPU if `torch.cuda.is_available()` is `False`.