### PR TITLE
Remove dependency duplicate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "uvicorn>=0.30.0",
     "loguru>=0.6.0",
     "loralib>=0.1.2",
-    "natsort>=8.4.0",
     "pyrootutils>=1.0.4",
     "vector_quantize_pytorch==1.14.24",
     "resampy>=0.4.3",


### PR DESCRIPTION
The PR removes a dependency duplicate that caused some issues getting started when I was using a conda/pypi derivative.

Below I'm linking the the current dates latest ref for quick access. The first and last line show the dupl
https://github.com/fishaudio/fish-speech/blob/b11bcf834a97a75073b535838e5f0765f169eb94/pyproject.toml#L22-L33