### PR TITLE
Fixed faulty mps device checking logic

### DIFF
--- a/tools/run_webui.py
+++ b/tools/run_webui.py
@@ -45,13 +45,11 @@ if __name__ == "__main__":
     args = parse_args()
     args.precision = torch.half if args.half else torch.bfloat16
 
-    # Check if MPS is available
+    # Check if MPS or CUDA is available
     if torch.backends.mps.is_available():
         args.device = "mps"
         logger.info("mps is available, running on mps.")
-
-    # Check if CUDA is available
-    if not torch.cuda.is_available():
+    elif not torch.cuda.is_available():
         logger.info("CUDA is not available, running on CPU.")
         args.device = "cpu"
 

--- a/tools/server/model_manager.py
+++ b/tools/server/model_manager.py
@@ -34,13 +34,11 @@ class ModelManager:
 
         self.precision = torch.half if half else torch.bfloat16
 
-        # Check if MPS is available
+        # Check if MPS or CUDA is available
         if torch.backends.mps.is_available():
             self.device = "mps"
             logger.info("mps is available, running on mps.")
-
-        # Check if CUDA is available
-        if not torch.cuda.is_available():
+        elif not torch.cuda.is_available():
             self.device = "cpu"
             logger.info("CUDA is not available, running on CPU.")
 


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.

This pull request fixes the faulty logic from https://github.com/fishaudio/fish-speech/pull/714/files which would have never worked as the secondary CUDA check would have overridden the device with "cpu" every time.

![Screenshot 2024-12-12 at 18 21 15](https://github.com/user-attachments/assets/27dc9d94-0c7f-419a-8fdd-bd88a8f846a0)
