### PR TITLE
fix: no-play argument for API client

### DIFF
--- a/tools/api_client.py
+++ b/tools/api_client.py
@@ -61,7 +61,7 @@ def parse_args():
     )
     parser.add_argument(
         "--play",
-        type=bool,
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Whether to play audio after receiving data",
     )


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.

**Is this pull request related to any issue? If yes, please link the issue.**

N/A

**Description**

Currently, `--play` has no effect because its default value is `True`. The parser does not recognize anything like `--play False`. It only detect whether the argument exists.

Therefore, we can use [BooleanOptionalAction](https://docs.python.org/3/library/argparse.html#argparse.BooleanOptionalAction), which automatically add the `--no-play` option, so that the play argument can be set to `False`.

**Compatibility**

This change does not break the existing behaviors because it adds a new option.