### PR TITLE
feat: Bearer auth for HTTP API

### DIFF
--- a/tools/api_client.py
+++ b/tools/api_client.py
@@ -119,6 +119,12 @@ def parse_args():
         help="`None` means randomized inference, otherwise deterministic.\n"
         "It can't be used for fixing a timbre.",
     )
+    parser.add_argument(
+        "--api_key",
+        type=str,
+        default="YOUR_API_KEY",
+        help="API key for authentication",
+    )
 
     return parser.parse_args()
 
@@ -173,7 +179,7 @@ if __name__ == "__main__":
         data=ormsgpack.packb(pydantic_data, option=ormsgpack.OPT_SERIALIZE_PYDANTIC),
         stream=args.streaming,
         headers={
-            "authorization": "Bearer YOUR_API_KEY",
+            "authorization": f"Bearer {args.api_key}",
             "content-type": "application/msgpack",
         },
     )

--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -1,12 +1,19 @@
 from threading import Lock
-from typing_extensions import Annotated
 
 import pyrootutils
 import uvicorn
-from kui.asgi import Depends
-from kui.asgi import FactoryClass, HTTPException, HttpRoute, Kui, OpenAPI, Routes
+from kui.asgi import (
+    Depends,
+    FactoryClass,
+    HTTPException,
+    HttpRoute,
+    Kui,
+    OpenAPI,
+    Routes,
+)
 from kui.security import bearer_auth
 from loguru import logger
+from typing_extensions import Annotated
 
 pyrootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 

--- a/tools/server/api_utils.py
+++ b/tools/server/api_utils.py
@@ -32,6 +32,7 @@ def parse_args():
     parser.add_argument("--max-text-length", type=int, default=0)
     parser.add_argument("--listen", type=str, default="127.0.0.1:8080")
     parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--api-key", type=str, default=None)
 
     return parser.parse_args()
 


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Add feature.

**Is this pull request related to any issue? If yes, please link the issue.**

N/A

**Description**

In tools/api_client.py, it already implements the header for bearer auth. This PR is to complete the configurations for this feature.

**Details**

- tools/api_client.py
  - Add argument `--api_key` to specify the authentication token.
  - The default value is "YOUR_API_KEY", which remains the previous behavior.
- tools/server/api_utils.py
  - Add argument `--api_key` to specify the authentication token.
- tools/api_server.py
  - Add a middleware to verify the `api_key` if it is provided.

**Compatibility**

If the new arguments are not specified, the previous behavior will not change.

