### PR TITLE
fix: update command to start WebUI in documentation

### DIFF
--- a/docs/en/inference.md
+++ b/docs/en/inference.md
@@ -119,7 +119,7 @@ The currently supported reference audio has a maximum total duration of 90 secon
 You can start the WebUI using the following command:
 
 ```bash
-python -m tools.webui \
+python -m tools.run_webui \
     --llama-checkpoint-path "checkpoints/fish-speech-1.5" \
     --decoder-checkpoint-path "checkpoints/fish-speech-1.5/firefly-gan-vq-fsq-8x1024-21hz-generator.pth" \
     --decoder-config-name firefly_gan_vq

--- a/docs/ja/inference.md
+++ b/docs/ja/inference.md
@@ -98,7 +98,7 @@ python -m tools.api_client \
 次のコマンドを使用して WebUI を起動できます：
 
 ```bash
-python -m tools.webui \
+python -m tools.run_webui \
     --llama-checkpoint-path "checkpoints/fish-speech-1.5" \
     --decoder-checkpoint-path "checkpoints/fish-speech-1.5/firefly-gan-vq-fsq-8x1024-21hz-generator.pth" \
     --decoder-config-name firefly_gan_vq

--- a/docs/ko/inference.md
+++ b/docs/ko/inference.md
@@ -117,7 +117,7 @@ python -m tools.api_client \
 다음 명령으로 WebUI를 시작할 수 있습니다:
 
 ```bash
-python -m tools.webui \
+python -m tools.run_webui \
     --llama-checkpoint-path "checkpoints/fish-speech-1.5" \
     --decoder-checkpoint-path "checkpoints/fish-speech-1.5/firefly-gan-vq-fsq-8x1024-21hz-generator.pth" \
     --decoder-config-name firefly_gan_vq

--- a/docs/pt/inference.md
+++ b/docs/pt/inference.md
@@ -98,7 +98,7 @@ O comando acima indica a síntese do áudio desejada de acordo com as informaç�
 Para iniciar a WebUI de Inferência execute o seguinte comando:
 
 ```bash
-python -m tools.webui \
+python -m tools.run_webui \
     --llama-checkpoint-path "checkpoints/fish-speech-1.5" \
     --decoder-checkpoint-path "checkpoints/fish-speech-1.5/firefly-gan-vq-fsq-8x1024-21hz-generator.pth" \
     --decoder-config-name firefly_gan_vq

--- a/docs/zh/inference.md
+++ b/docs/zh/inference.md
@@ -127,7 +127,7 @@ python -m tools.api_client \
 你可以使用以下命令来启动 WebUI:
 
 ```bash
-python -m tools.webui \
+python -m tools.run_webui \
     --llama-checkpoint-path "checkpoints/fish-speech-1.5" \
     --decoder-checkpoint-path "checkpoints/fish-speech-1.5/firefly-gan-vq-fsq-8x1024-21hz-generator.pth" \
     --decoder-config-name firefly_gan_vq


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG (Documentation improvement).

**Is this pull request related to any issue? If yes, please link the issue.**

No related issue.

---
https://github.com/fishaudio/fish-speech/commit/62eae262c20d5a83db5c825383993d548f82b813

This commit from last week on the PR has made several changes, and as someone who is just getting familiar with the project, I found that I couldn't successfully start the web UI based on the documentation.  



<img width="2390" alt="image" src="https://github.com/user-attachments/assets/4ca2c26b-3ccd-46a0-b331-9861b3eaad4b" />


<img width="2230" alt="image" src="https://github.com/user-attachments/assets/93faeab7-8e48-42a1-a85b-15b546bd15a3" />

After some investigation, I pinpointed the issue—I was supposed to use `tools.run_webui` instead of `tools.webui`.  



Once I made that change, everything worked as expected.  
![image](https://github.com/user-attachments/assets/a440adde-7328-4c7e-b857-30f75ffd9850)
The purpose of my current PR is to improve the documentation so that future users can more easily start the web UI. Honestly, I really enjoy using the web UI, and I hope these adjustments can help others.

---
