### PR TITLE
add Python interface

### DIFF
--- a/fish_speech/inference_engine/__init__.py
+++ b/fish_speech/inference_engine/__init__.py
@@ -48,7 +48,7 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
 
         ref_id: str | None = req.reference_id
         prompt_tokens, prompt_texts = [], []
-        # Load the reference audio and text based on id or hash
+        # Load the reference audio and text based on id, hash, or preprocessed references
         if ref_id is not None:
             prompt_tokens, prompt_texts = self.load_by_id(ref_id, req.use_memory_cache)
 
@@ -56,6 +56,10 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             prompt_tokens, prompt_texts = self.load_by_hash(
                 req.references, req.use_memory_cache
             )
+        
+        elif req.preprocessed_references:
+            prompt_tokens = [ref.tokens for ref in req.preprocessed_references]
+            prompt_texts = [ref.text for ref in req.preprocessed_references]
 
         # Set the random seed if provided
         if req.seed is not None:
@@ -106,7 +110,7 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             if result.action != "next":
                 segment = self.get_audio_segment(result)
 
-                if req.streaming:  # Used only by the API server
+                if req.streaming:
                     yield InferenceResult(
                         code="segment",
                         audio=(sample_rate, segment),

--- a/fish_speech/lib/__init__.py
+++ b/fish_speech/lib/__init__.py
@@ -1,0 +1,110 @@
+from typing import List, Tuple, Dict, Any, Optional, Literal, Union
+import warnings
+import torch
+
+from fish_speech.models.text2semantic.inference import launch_thread_safe_queue
+from fish_speech.models.vqgan.inference import load_model as load_vqgan_model
+from fish_speech.inference_engine import TTSInferenceEngine
+from fish_speech.utils.schema import ServeTTSRequest
+
+Device = Literal["cuda", "mps", "cpu"]
+
+
+class Pipeline:
+
+    def __init__(
+            self,
+            llama_path: str,
+            vqgan_path: str,
+            vqgan_config: str,
+            device: Device = "cpu",
+            half: bool = False,
+            compile: bool = False,
+            ) -> None:
+
+        # Validate input
+        assert isinstance(llama_path, str), "llama_path must be a string."
+        assert isinstance(vqgan_path, str), "vqgan_path must be a string."
+        assert isinstance(vqgan_config, str), "vqgan_config must be a string."
+        assert isinstance(half, bool), "half must be a boolean."
+        assert isinstance(compile, bool), "compile must be a boolean."
+
+        device = self.check_device(device)
+        precision = torch.half if half else torch.bfloat16
+
+        self.llama = self.load_llama(llama_path, device, precision, compile)
+        self.vqgan = self.load_vqgan(vqgan_config, vqgan_path, device)
+
+        self.inference_engine = TTSInferenceEngine(
+            llama_queue=self.llama,
+            decoder_model=self.vqgan,
+            precision=precision,
+            compile=compile,
+        )
+
+        self.warmup(self.inference_engine)
+
+
+    def check_device(self, device: str) -> Device:
+        device = device.lower()
+
+        # If CUDA or MPS chosen, check if available
+        match device:
+            case "cuda":
+                if not torch.cuda.is_available():
+                    warnings.warn("CUDA is not available, running on CPU.")
+                    device = "cpu"
+            case "mps":
+                if not torch.backends.mps.is_available():
+                    warnings.warn("MPS is not available, running on CPU.")
+                    device = "cpu"
+            case "cpu":
+                pass
+            case _:
+                raise ValueError("Invalid device, choose from 'cuda', 'mps', 'cpu'.")
+        
+        return device
+    
+
+    def load_llama(self, llama_path: str, device: str, precision: torch.dtype, compile: bool) -> Any:
+        try:
+            return launch_thread_safe_queue(
+                checkpoint_path=llama_path,
+                device=device,
+                precision=precision,
+                compile=compile,
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to load LLAMA model: {e}")
+    
+
+    def load_vqgan(self, vqgan_config: str, vqgan_path: str, device: str) -> Any:
+        try:
+            return load_vqgan_model(
+                config_name=vqgan_config,
+                checkpoint_path=vqgan_path,
+                device=device,
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to load VQ-GAN model: {e}")
+
+
+    def warmup(self, inference_engine: TTSInferenceEngine) -> None:
+        try:
+            list(
+                inference_engine.inference(
+                    ServeTTSRequest(
+                        text="Hello world.",
+                        references=[],
+                        reference_id=None,
+                        max_new_tokens=1024,
+                        chunk_length=200,
+                        top_p=0.7,
+                        repetition_penalty=1.5,
+                        temperature=0.7,
+                        format="wav",
+                    )
+                )
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to warm up the inference engine: {e}")

--- a/fish_speech/lib/__init__.py
+++ b/fish_speech/lib/__init__.py
@@ -1,8 +1,8 @@
-from typing import List, Tuple, Dict, Any, Optional, Literal, Union, Generator
-import warnings
 import torch
-from queue import Queue
+import warnings
 import numpy as np
+from queue import Queue
+from typing import List, Optional, Literal, Union, Generator
 
 from fish_speech.models.text2semantic.inference import launch_thread_safe_queue
 from fish_speech.models.vqgan.inference import load_model as load_vqgan_model
@@ -155,6 +155,7 @@ class Pipeline:
             seed: Optional[int] = None,
             streaming: bool = False,
             max_new_tokens: int = 0,
+            chunk_length: int = 200,
             top_p: Optional[float] = None,
             repetition_penalty: Optional[float] = None,
             temperature: Optional[float] = None,
@@ -168,6 +169,7 @@ class Pipeline:
             seed (Optional[int], optional): Random seed. Defaults to None.
             streaming (bool, optional): Stream the audio. Defaults to False.
             max_new_tokens (int, optional): Maximum number of tokens. Defaults to 0 (no limit).
+            chunk_length (int, optional): Chunk length for streaming. Defaults to 200.
             top_p (Optional[float], optional): Top-p sampling. Defaults to None.
             repetition_penalty (Optional[float], optional): Repetition penalty. Defaults to None.
             temperature (Optional[float], optional): Sampling temperature. Defaults to None.
@@ -180,6 +182,7 @@ class Pipeline:
             seed=seed,
             streaming=streaming,
             max_new_tokens=max_new_tokens,
+            chunk_length=chunk_length,
             top_p=top_p or 0.7,
             repetition_penalty=repetition_penalty or 1.2,
             temperature=temperature or 0.7,
@@ -219,6 +222,7 @@ class Pipeline:
             seed: Optional[int] = None,
             streaming: bool = False,
             max_new_tokens: int = 0,
+            chunk_length: int = 200,
             top_p: Optional[float] = None,
             repetition_penalty: Optional[float] = None,
             temperature: Optional[float] = None,
@@ -233,6 +237,7 @@ class Pipeline:
             seed (Optional[int], optional): Random seed. Defaults to None.
             streaming (bool, optional): Stream the audio. Defaults to False.
             max_new_tokens (int, optional): Maximum number of tokens. Defaults to 0 (no limit).
+            chunk_length (int, optional): Chunk length for streaming. Defaults to 200.
             top_p (Optional[float], optional): Top-p sampling. Defaults to None.
             repetition_penalty (Optional[float], optional): Repetition penalty. Defaults to None.
             temperature (Optional[float], optional): Sampling temperature. Defaults to None.
@@ -244,6 +249,7 @@ class Pipeline:
             seed=seed,
             streaming=streaming,
             max_new_tokens=max_new_tokens,
+            chunk_length=chunk_length,
             top_p=top_p,
             repetition_penalty=repetition_penalty,
             temperature=temperature,

--- a/fish_speech/models/vqgan/inference.py
+++ b/fish_speech/models/vqgan/inference.py
@@ -21,7 +21,6 @@ OmegaConf.register_new_resolver("eval", eval)
 
 
 def load_model(config_name, checkpoint_path, device="cuda"):
-    hydra.core.global_hydra.GlobalHydra.instance().clear()
     with initialize(version_base="1.3", config_path="../../configs"):
         cfg = compose(config_name=config_name)
 

--- a/fish_speech/utils/schema.py
+++ b/fish_speech/utils/schema.py
@@ -2,7 +2,7 @@ import base64
 import os
 import queue
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Any
 
 import torch
 from pydantic import BaseModel, Field, conint, conlist, model_validator
@@ -158,6 +158,15 @@ class ServeReferenceAudio(BaseModel):
         return f"ServeReferenceAudio(text={self.text!r}, audio_size={len(self.audio)})"
 
 
+class Reference(BaseModel):
+    tokens: torch.Tensor
+    text: str
+
+    # Allow arbitrary types for pytorch related types
+    class Config:
+        arbitrary_types_allowed = True
+
+
 class ServeTTSRequest(BaseModel):
     text: str
     chunk_length: Annotated[int, conint(ge=100, le=300, strict=True)] = 200
@@ -165,6 +174,7 @@ class ServeTTSRequest(BaseModel):
     format: Literal["wav", "pcm", "mp3"] = "wav"
     # References audios for in-context learning
     references: list[ServeReferenceAudio] = []
+    preprocessed_references: list[Reference] = []
     # Reference id
     # For example, if you want use https://fish.audio/m/7f92f8afb8ec43bf81429cc1c9199cb1/
     # Just pass 7f92f8afb8ec43bf81429cc1c9199cb1


### PR DESCRIPTION
This PR allows to use Fish Speech as an importable Python library for easy integration in code.
It adds the sub-directory `lib` in the main directory and mainly relies on the dedicated `Pipeline` class.

Here is an example of use:
```python
# Optionnal: remove prints in terminal
import os
from loguru import logger

logger.remove()
os.environ["TQDM_DISABLE"] = "1"

# Prepare the models
from fish_speech.lib import Pipeline

model = Pipeline(
    llama_path = "models/fish-speech-1_5",
    vqgan_path = "models/vqgan-1_5.pth",
)

# Create a reference audio
ref = model.make_reference("ref.wav", "reference text")

# Generate audio (no streaming)
output = model.generate("text to generate.", ref)

# Generate audio (streaming)
import numpy as np

generator = model.generate("text to generate.", ref, streaming=True)

parts = []
for part in generator:
    parts.append(part)
    print(part.shape)

output = np.concatenate(parts, axis=0)

# Save the output to a file
sample_rate = model.sample_rate

import soundfile as sf
sf.write("output.wav", output, sample_rate)
```

This PR is not complete yet as it's missing:
1 - Documentation. Question: Where do you want to put it?
2 - The code still depends on `.project-root` to manage paths, making it impossible to install in non-editable mode, forcing the user to keep the source code in a separate folder. I'd be glad if you have suggestions for this part.