### PR TITLE
Fix: Update incorrect import path for load_filelist function

### DIFF
--- a/tools/llama/build_dataset.py
+++ b/tools/llama/build_dataset.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from fish_speech.datasets.protos.text_data_pb2 import Semantics, Sentence, TextData
 from fish_speech.datasets.protos.text_data_stream import pack_pb_stream
 from fish_speech.utils.file import load_filelist
+
 # To avoid CPU overload
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"

--- a/tools/llama/build_dataset.py
+++ b/tools/llama/build_dataset.py
@@ -12,8 +12,8 @@ from loguru import logger
 from tqdm import tqdm
 
 from fish_speech.datasets.protos.text_data_pb2 import Semantics, Sentence, TextData
-from fish_speech.datasets.protos.text_data_stream import load_filelist, pack_pb_stream
-
+from fish_speech.datasets.protos.text_data_stream import pack_pb_stream
+from fish_speech.utils.file import load_filelist
 # To avoid CPU overload
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**
Fix BUG

**Is this pull request related to any issue? If yes, please link the issue.**
N/A

The `load_filelist` function was incorrectly imported from `fish_speech.datasets.protos.text_data_stream` when it has been moved to `fish_speech.utils.file`. This PR updates the import statement to use the correct path.

Changes:
- Remove import of `load_filelist` from text_data_stream
- Add import of `load_filelist` from fish_speech.utils.file

This fixes potential import errors and maintains consistency with the current project structure.
