### PR TITLE
fix bugs in onnx tracer

### DIFF
--- a/fish_speech/models/vqgan/modules/firefly.py
+++ b/fish_speech/models/vqgan/modules/firefly.py
@@ -45,9 +45,13 @@ def get_extra_padding_for_conv1d(
     n_frames = (length - kernel_size + padding_total) / stride + 1
     # for tracer, math.ceil will make onnx graph become constant
     if isinstance(n_frames, torch.Tensor):
-        ideal_length = (torch.ceil(n_frames).long() - 1) * stride + (kernel_size - padding_total)
+        ideal_length = (torch.ceil(n_frames).long() - 1) * stride + (
+            kernel_size - padding_total
+        )
     else:
-        ideal_length = (math.ceil(n_frames) - 1) * stride + (kernel_size - padding_total)
+        ideal_length = (math.ceil(n_frames) - 1) * stride + (
+            kernel_size - padding_total
+        )
     return ideal_length - length
 
 

--- a/fish_speech/models/vqgan/modules/firefly.py
+++ b/fish_speech/models/vqgan/modules/firefly.py
@@ -43,7 +43,11 @@ def get_extra_padding_for_conv1d(
     """See `pad_for_conv1d`."""
     length = x.shape[-1]
     n_frames = (length - kernel_size + padding_total) / stride + 1
-    ideal_length = (math.ceil(n_frames) - 1) * stride + (kernel_size - padding_total)
+    # for tracer, math.ceil will make onnx graph become constant
+    if isinstance(n_frames, torch.Tensor):
+        ideal_length = (torch.ceil(n_frames).long() - 1) * stride + (kernel_size - padding_total)
+    else:
+        ideal_length = (math.ceil(n_frames) - 1) * stride + (kernel_size - padding_total)
     return ideal_length - length
 
 

--- a/fish_speech/utils/spectrogram.py
+++ b/fish_speech/utils/spectrogram.py
@@ -20,6 +20,7 @@ class LinearSpectrogram(nn.Module):
         self.hop_length = hop_length
         self.center = center
         self.mode = mode
+        self.return_complex = True
 
         self.register_buffer("window", torch.hann_window(win_length), persistent=False)
 
@@ -46,10 +47,11 @@ class LinearSpectrogram(nn.Module):
             pad_mode="reflect",
             normalized=False,
             onesided=True,
-            return_complex=True,
+            return_complex=self.return_complex,
         )
 
-        spec = torch.view_as_real(spec)
+        if self.return_complex:
+            spec = torch.view_as_real(spec)
 
         if self.mode == "pow2_sqrt":
             spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)

--- a/tools/export-onnx.py
+++ b/tools/export-onnx.py
@@ -1,10 +1,12 @@
-from tools.vqgan.extract_vq import get_model
-from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
-import torch.nn.functional as F
-import torch
 import onnxruntime
+import torch
+import torch.nn.functional as F
+
+from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
+from tools.vqgan.extract_vq import get_model
 
 PAD_TOKEN_ID = torch.LongTensor([CODEBOOK_PAD_TOKEN_ID])
+
 
 class Encoder(torch.nn.Module):
     def __init__(self, model):
@@ -20,7 +22,8 @@ class Encoder(torch.nn.Module):
         _, indices = self.model.quantizer.residual_fsq(z.transpose(-2, -1))
         _, b, l, _ = indices.shape
         return indices.permute(1, 0, 3, 2).long().view(b, -1, l)
-        
+
+
 class Decoder(torch.nn.Module):
     def __init__(self, model):
         super().__init__()
@@ -33,9 +36,22 @@ class Decoder(torch.nn.Module):
         _, quantize_dim, _ = indices.shape
         d_dim = self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.shape[2]
 
-        if quantize_dim < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers:
-            assert self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0., 'quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations'
-            indices = F.pad(indices, (0, self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers - quantize_dim), value = -1)
+        if (
+            quantize_dim
+            < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
+        ):
+            assert (
+                self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0.0
+            ), "quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations"
+            indices = F.pad(
+                indices,
+                (
+                    0,
+                    self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
+                    - quantize_dim,
+                ),
+                value=-1,
+            )
 
         mask = indices == -1
         indices = indices.masked_fill(mask, 0)
@@ -43,12 +59,16 @@ class Decoder(torch.nn.Module):
         all_codes = torch.gather(
             self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.unsqueeze(1),
             dim=2,
-            index=indices.permute(2, 0, 1).unsqueeze(-1).repeat(1,1,1,d_dim)
+            index=indices.permute(2, 0, 1).unsqueeze(-1).repeat(1, 1, 1, d_dim),
         )
 
-        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.)
+        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.0)
 
-        scales = self.model.quantizer.residual_fsq.rvqs[cur_index].scales.unsqueeze(1).unsqueeze(1)
+        scales = (
+            self.model.quantizer.residual_fsq.rvqs[cur_index]
+            .scales.unsqueeze(1)
+            .unsqueeze(1)
+        )
         all_codes = all_codes * scales
 
         return all_codes
@@ -56,7 +76,9 @@ class Decoder(torch.nn.Module):
     def get_output_from_indices(self, cur_index, indices):
         codes = self.get_codes_from_indices(cur_index, indices)
         codes_summed = codes.sum(dim=0)
-        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(codes_summed)
+        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(
+            codes_summed
+        )
 
     def forward(self, indices) -> torch.Tensor:
         batch_size, _, length = indices.shape
@@ -64,30 +86,23 @@ class Decoder(torch.nn.Module):
         groups = self.model.quantizer.residual_fsq.groups
         dim_per_group = dims // groups
 
-        #indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
-        indices = indices.view(
-            batch_size, groups, -1, length
-        ).permute(1, 0, 3, 2)
+        # indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
+        indices = indices.view(batch_size, groups, -1, length).permute(1, 0, 3, 2)
 
-        #z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
+        # z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
         z_q = torch.empty((batch_size, length, dims))
         for i in range(groups):
-            z_q[:,:,i*dim_per_group:(i+1)*dim_per_group] = self.get_output_from_indices(i, indices[i])
+            z_q[:, :, i * dim_per_group : (i + 1) * dim_per_group] = (
+                self.get_output_from_indices(i, indices[i])
+            )
 
         z = self.model.quantizer.upsample(z_q.transpose(1, 2))
         x = self.model.head(z)
         return x
 
-def main(
-        firefly_gan_vq_path,
-        llama_path, 
-        export_prefix
-    ):
-    GanModel = get_model(
-        "firefly_gan_vq",
-        firefly_gan_vq_path, 
-        device="cpu"
-    )
+
+def main(firefly_gan_vq_path, llama_path, export_prefix):
+    GanModel = get_model("firefly_gan_vq", firefly_gan_vq_path, device="cpu")
     enc = Encoder(GanModel)
     dec = Decoder(GanModel)
     audio_example = torch.randn(1, 1, 96000)
@@ -96,34 +111,28 @@ def main(
         enc,
         audio_example,
         f"{export_prefix}encoder.onnx",
-        dynamic_axes = {
-            "audio": {
-                0:"batch_size", 
-                2:"audio_length"
-            },
+        dynamic_axes={
+            "audio": {0: "batch_size", 2: "audio_length"},
         },
         do_constant_folding=False,
         opset_version=18,
         verbose=False,
         input_names=["audio"],
-        output_names=["prompt"]
+        output_names=["prompt"],
     )
-    
+
     torch.onnx.export(
         dec,
         indices,
         f"{export_prefix}decoder.onnx",
-        dynamic_axes = {
-            "prompt": {
-                0:"batch_size", 
-                2:"frame_count"
-            },
+        dynamic_axes={
+            "prompt": {0: "batch_size", 2: "frame_count"},
         },
         do_constant_folding=False,
         opset_version=18,
         verbose=False,
         input_names=["prompt"],
-        output_names=["audio"]
+        output_names=["audio"],
     )
 
     test_example = torch.randn(1, 1, 96000 * 5)
@@ -131,15 +140,11 @@ def main(
     decoder_session = onnxruntime.InferenceSession(f"{export_prefix}decoder.onnx")
 
     # check graph has no error
-    onnx_enc_out = encoder_session.run(["prompt"], {"audio":test_example.numpy()})[0]
+    onnx_enc_out = encoder_session.run(["prompt"], {"audio": test_example.numpy()})[0]
     torch_enc_out = enc(test_example)
-    onnx_dec_out = decoder_session.run(["audio"], {"prompt":onnx_enc_out})[0]
+    onnx_dec_out = decoder_session.run(["audio"], {"prompt": onnx_enc_out})[0]
     torch_dec_out = dec(torch_enc_out)
-    
+
 
 if __name__ == "__main__":
-    main(
-        "checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth", 
-        None,
-        "test_"
-    )
+    main("checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth", None, "test_")

--- a/tools/export-onnx.py
+++ b/tools/export-onnx.py
@@ -1,0 +1,127 @@
+from tools.vqgan.extract_vq import get_model
+from einx import get_at
+from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
+import torch.nn.functional as F
+import torch
+
+PAD_TOKEN_ID = torch.LongTensor([CODEBOOK_PAD_TOKEN_ID])
+
+class Encoder(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.model.spec_transform.spectrogram.return_complex = False
+
+    def forward(self, audios):
+        mels = self.model.spec_transform(audios)
+        encoded_features = self.model.backbone(mels)
+        indices = self.model.quantizer.encode(encoded_features)
+        return indices
+        
+class Decoder(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.model.head.training = False
+        self.model.head.checkpointing = False
+
+    def get_codes_from_indices(self, cur_index, indices):
+
+        batch_size, quantize_dim, q_dim = indices.shape
+        d_dim = self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.shape[2]
+
+        # because of quantize dropout, one can pass in indices that are coarse
+        # and the network should be able to reconstruct
+
+        if quantize_dim < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers:
+            assert self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0., 'quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations'
+            indices = F.pad(indices, (0, self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers - quantize_dim), value = -1)
+
+        # take care of quantizer dropout
+
+        mask = indices == -1
+        indices = indices.masked_fill(mask, 0) # have it fetch a dummy code to be masked out later
+
+        all_codes = torch.gather(
+            self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.unsqueeze(1),
+            dim=2,
+            index=indices.long().permute(2, 0, 1).unsqueeze(-1).repeat(1,1,1,d_dim)   #q, batch_size, frame, dim
+        )
+
+        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.)
+
+        # scale the codes
+
+        scales = self.model.quantizer.residual_fsq.rvqs[cur_index].scales.unsqueeze(1).unsqueeze(1)
+        all_codes = all_codes * scales
+
+        # if (accept_image_fmap = True) then return shape (quantize, batch, height, width, dimension)
+
+        return all_codes
+
+    def get_output_from_indices(self, cur_index, indices):
+        codes = self.get_codes_from_indices(cur_index, indices)
+        codes_summed = codes.sum(dim=0)
+        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(codes_summed)
+
+    def forward(self, indices) -> torch.Tensor:
+        batch_size, _, length = indices.shape
+        dims = self.model.quantizer.residual_fsq.dim
+        groups = self.model.quantizer.residual_fsq.groups
+        dim_per_group = dims // groups
+
+        #indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
+        indices = indices.view(batch_size, groups, -1, length).permute(1, 0, 3, 2)
+
+        #z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
+        z_q = torch.empty((batch_size, length, dims))
+        for i in range(groups):
+            z_q[:,:,i*dim_per_group:(i+1)*dim_per_group] = self.get_output_from_indices(i, indices[i])
+
+        z = self.model.quantizer.upsample(z_q.transpose(1, 2))
+        x = self.model.head(z)
+        return x
+
+def main():
+    GanModel = get_model("firefly_gan_vq", "checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth", device="cpu")
+    enc = Encoder(GanModel)
+    dec = Decoder(GanModel)
+    audio_example = torch.randn(1, 1, 96000)
+    indices = enc(audio_example)
+
+    print(dec(indices).shape)
+
+    '''
+    torch.onnx.export(
+        enc,
+        audio_example,
+        "encoder.onnx",
+        dynamic_axes = {
+            "audio": [0, 2],
+        },
+        do_constant_folding=False,
+        opset_version=18,
+        verbose=False,
+        input_names=["audio"],
+        output_names=["prompt"]
+    )
+    '''
+
+    torch.onnx.export(
+        dec,
+        indices,
+        "decoder.onnx",
+        dynamic_axes = {
+            "prompt": [0, 2],
+        },
+        do_constant_folding=False,
+        opset_version=18,
+        verbose=False,
+        input_names=["prompt"],
+        output_names=["audio"]
+    )
+
+    print(enc(audio_example).shape)
+    print(dec(enc(audio_example)).shape)
+
+main()

--- a/tools/export-onnx.py
+++ b/tools/export-onnx.py
@@ -1,12 +1,9 @@
-import torch
-import torch.nn.functional as F
-from einx import get_at
-
-from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
 from tools.vqgan.extract_vq import get_model
+from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
+import torch.nn.functional as F
+import torch
 
 PAD_TOKEN_ID = torch.LongTensor([CODEBOOK_PAD_TOKEN_ID])
-
 
 class Encoder(torch.nn.Module):
     def __init__(self, model):
@@ -17,10 +14,12 @@ class Encoder(torch.nn.Module):
     def forward(self, audios):
         mels = self.model.spec_transform(audios)
         encoded_features = self.model.backbone(mels)
-        indices = self.model.quantizer.encode(encoded_features)
-        return indices
 
-
+        z = self.model.quantizer.downsample(encoded_features)
+        _, indices = self.model.quantizer.residual_fsq(z.transpose(-2, -1))
+        _, b, l, _ = indices.shape
+        return indices.permute(1, 0, 3, 2).contiguous().view(b, -1, l)
+        
 class Decoder(torch.nn.Module):
     def __init__(self, model):
         super().__init__()
@@ -30,66 +29,33 @@ class Decoder(torch.nn.Module):
 
     def get_codes_from_indices(self, cur_index, indices):
 
-        batch_size, quantize_dim, q_dim = indices.shape
+        _, quantize_dim, _ = indices.shape
         d_dim = self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.shape[2]
 
-        # because of quantize dropout, one can pass in indices that are coarse
-        # and the network should be able to reconstruct
-
-        if (
-            quantize_dim
-            < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
-        ):
-            assert (
-                self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0.0
-            ), "quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations"
-            indices = F.pad(
-                indices,
-                (
-                    0,
-                    self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
-                    - quantize_dim,
-                ),
-                value=-1,
-            )
-
-        # take care of quantizer dropout
+        if quantize_dim < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers:
+            assert self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0., 'quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations'
+            indices = F.pad(indices, (0, self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers - quantize_dim), value = -1)
 
         mask = indices == -1
-        indices = indices.masked_fill(
-            mask, 0
-        )  # have it fetch a dummy code to be masked out later
+        indices = indices.masked_fill(mask, 0)
 
         all_codes = torch.gather(
             self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.unsqueeze(1),
             dim=2,
-            index=indices.long()
-            .permute(2, 0, 1)
-            .unsqueeze(-1)
-            .repeat(1, 1, 1, d_dim),  # q, batch_size, frame, dim
+            index=indices.long().permute(2, 0, 1).unsqueeze(-1).repeat(1,1,1,d_dim)
         )
 
-        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.0)
+        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.)
 
-        # scale the codes
-
-        scales = (
-            self.model.quantizer.residual_fsq.rvqs[cur_index]
-            .scales.unsqueeze(1)
-            .unsqueeze(1)
-        )
+        scales = self.model.quantizer.residual_fsq.rvqs[cur_index].scales.unsqueeze(1).unsqueeze(1)
         all_codes = all_codes * scales
-
-        # if (accept_image_fmap = True) then return shape (quantize, batch, height, width, dimension)
 
         return all_codes
 
     def get_output_from_indices(self, cur_index, indices):
         codes = self.get_codes_from_indices(cur_index, indices)
         codes_summed = codes.sum(dim=0)
-        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(
-            codes_summed
-        )
+        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(codes_summed)
 
     def forward(self, indices) -> torch.Tensor:
         batch_size, _, length = indices.shape
@@ -97,39 +63,28 @@ class Decoder(torch.nn.Module):
         groups = self.model.quantizer.residual_fsq.groups
         dim_per_group = dims // groups
 
-        # indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
+        #indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
         indices = indices.view(batch_size, groups, -1, length).permute(1, 0, 3, 2)
 
-        # z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
+        #z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
         z_q = torch.empty((batch_size, length, dims))
         for i in range(groups):
-            z_q[:, :, i * dim_per_group : (i + 1) * dim_per_group] = (
-                self.get_output_from_indices(i, indices[i])
-            )
+            z_q[:,:,i*dim_per_group:(i+1)*dim_per_group] = self.get_output_from_indices(i, indices[i])
 
         z = self.model.quantizer.upsample(z_q.transpose(1, 2))
         x = self.model.head(z)
         return x
 
-
-def main():
-    GanModel = get_model(
-        "firefly_gan_vq",
-        "checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth",
-        device="cpu",
-    )
+def main(firefly_gan_vq_path, llama_path, export_prefix):
+    GanModel = get_model("firefly_gan_vq", firefly_gan_vq_path, device="cpu")
     enc = Encoder(GanModel)
     dec = Decoder(GanModel)
     audio_example = torch.randn(1, 1, 96000)
     indices = enc(audio_example)
-
-    print(dec(indices).shape)
-
-    """
     torch.onnx.export(
         enc,
         audio_example,
-        "encoder.onnx",
+        f"{export_prefix}encoder.onnx",
         dynamic_axes = {
             "audio": [0, 2],
         },
@@ -139,24 +94,25 @@ def main():
         input_names=["audio"],
         output_names=["prompt"]
     )
-    """
-
+    
     torch.onnx.export(
         dec,
         indices,
-        "decoder.onnx",
-        dynamic_axes={
+        f"{export_prefix}decoder.onnx",
+        dynamic_axes = {
             "prompt": [0, 2],
         },
         do_constant_folding=False,
         opset_version=18,
         verbose=False,
         input_names=["prompt"],
-        output_names=["audio"],
+        output_names=["audio"]
     )
 
-    print(enc(audio_example).shape)
-    print(dec(enc(audio_example)).shape)
 
-
-main()
+if __name__ == "__main__":
+    main(
+        "checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth", 
+        None,
+        "test_"
+    )

--- a/tools/export-onnx.py
+++ b/tools/export-onnx.py
@@ -1,11 +1,10 @@
-import torch
-import torch.nn.functional as F
-
-from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
 from tools.vqgan.extract_vq import get_model
+from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
+import torch.nn.functional as F
+import torch
+import onnxruntime
 
 PAD_TOKEN_ID = torch.LongTensor([CODEBOOK_PAD_TOKEN_ID])
-
 
 class Encoder(torch.nn.Module):
     def __init__(self, model):
@@ -20,9 +19,8 @@ class Encoder(torch.nn.Module):
         z = self.model.quantizer.downsample(encoded_features)
         _, indices = self.model.quantizer.residual_fsq(z.transpose(-2, -1))
         _, b, l, _ = indices.shape
-        return indices.permute(1, 0, 3, 2).contiguous().view(b, -1, l)
-
-
+        return indices.permute(1, 0, 3, 2).long().view(b, -1, l)
+        
 class Decoder(torch.nn.Module):
     def __init__(self, model):
         super().__init__()
@@ -35,22 +33,9 @@ class Decoder(torch.nn.Module):
         _, quantize_dim, _ = indices.shape
         d_dim = self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.shape[2]
 
-        if (
-            quantize_dim
-            < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
-        ):
-            assert (
-                self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0.0
-            ), "quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations"
-            indices = F.pad(
-                indices,
-                (
-                    0,
-                    self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
-                    - quantize_dim,
-                ),
-                value=-1,
-            )
+        if quantize_dim < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers:
+            assert self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0., 'quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations'
+            indices = F.pad(indices, (0, self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers - quantize_dim), value = -1)
 
         mask = indices == -1
         indices = indices.masked_fill(mask, 0)
@@ -58,16 +43,12 @@ class Decoder(torch.nn.Module):
         all_codes = torch.gather(
             self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.unsqueeze(1),
             dim=2,
-            index=indices.long().permute(2, 0, 1).unsqueeze(-1).repeat(1, 1, 1, d_dim),
+            index=indices.permute(2, 0, 1).unsqueeze(-1).repeat(1,1,1,d_dim)
         )
 
-        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.0)
+        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.)
 
-        scales = (
-            self.model.quantizer.residual_fsq.rvqs[cur_index]
-            .scales.unsqueeze(1)
-            .unsqueeze(1)
-        )
+        scales = self.model.quantizer.residual_fsq.rvqs[cur_index].scales.unsqueeze(1).unsqueeze(1)
         all_codes = all_codes * scales
 
         return all_codes
@@ -75,9 +56,7 @@ class Decoder(torch.nn.Module):
     def get_output_from_indices(self, cur_index, indices):
         codes = self.get_codes_from_indices(cur_index, indices)
         codes_summed = codes.sum(dim=0)
-        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(
-            codes_summed
-        )
+        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(codes_summed)
 
     def forward(self, indices) -> torch.Tensor:
         batch_size, _, length = indices.shape
@@ -85,23 +64,30 @@ class Decoder(torch.nn.Module):
         groups = self.model.quantizer.residual_fsq.groups
         dim_per_group = dims // groups
 
-        # indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
-        indices = indices.view(batch_size, groups, -1, length).permute(1, 0, 3, 2)
+        #indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
+        indices = indices.view(
+            batch_size, groups, -1, length
+        ).permute(1, 0, 3, 2)
 
-        # z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
+        #z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
         z_q = torch.empty((batch_size, length, dims))
         for i in range(groups):
-            z_q[:, :, i * dim_per_group : (i + 1) * dim_per_group] = (
-                self.get_output_from_indices(i, indices[i])
-            )
+            z_q[:,:,i*dim_per_group:(i+1)*dim_per_group] = self.get_output_from_indices(i, indices[i])
 
         z = self.model.quantizer.upsample(z_q.transpose(1, 2))
         x = self.model.head(z)
         return x
 
-
-def main(firefly_gan_vq_path, llama_path, export_prefix):
-    GanModel = get_model("firefly_gan_vq", firefly_gan_vq_path, device="cpu")
+def main(
+        firefly_gan_vq_path,
+        llama_path, 
+        export_prefix
+    ):
+    GanModel = get_model(
+        "firefly_gan_vq",
+        firefly_gan_vq_path, 
+        device="cpu"
+    )
     enc = Encoder(GanModel)
     dec = Decoder(GanModel)
     audio_example = torch.randn(1, 1, 96000)
@@ -110,30 +96,50 @@ def main(firefly_gan_vq_path, llama_path, export_prefix):
         enc,
         audio_example,
         f"{export_prefix}encoder.onnx",
-        dynamic_axes={
-            "audio": [0, 2],
+        dynamic_axes = {
+            "audio": {
+                0:"batch_size", 
+                2:"audio_length"
+            },
         },
         do_constant_folding=False,
         opset_version=18,
         verbose=False,
         input_names=["audio"],
-        output_names=["prompt"],
+        output_names=["prompt"]
     )
-
+    
     torch.onnx.export(
         dec,
         indices,
         f"{export_prefix}decoder.onnx",
-        dynamic_axes={
-            "prompt": [0, 2],
+        dynamic_axes = {
+            "prompt": {
+                0:"batch_size", 
+                2:"frame_count"
+            },
         },
         do_constant_folding=False,
         opset_version=18,
         verbose=False,
         input_names=["prompt"],
-        output_names=["audio"],
+        output_names=["audio"]
     )
 
+    test_example = torch.randn(1, 1, 96000 * 5)
+    encoder_session = onnxruntime.InferenceSession(f"{export_prefix}encoder.onnx")
+    decoder_session = onnxruntime.InferenceSession(f"{export_prefix}decoder.onnx")
+
+    # check graph has no error
+    onnx_enc_out = encoder_session.run(["prompt"], {"audio":test_example.numpy()})[0]
+    torch_enc_out = enc(test_example)
+    onnx_dec_out = decoder_session.run(["audio"], {"prompt":onnx_enc_out})[0]
+    torch_dec_out = dec(torch_enc_out)
+    
 
 if __name__ == "__main__":
-    main("checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth", None, "test_")
+    main(
+        "checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth", 
+        None,
+        "test_"
+    )

--- a/tools/export-onnx.py
+++ b/tools/export-onnx.py
@@ -1,9 +1,11 @@
-from tools.vqgan.extract_vq import get_model
-from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
-import torch.nn.functional as F
 import torch
+import torch.nn.functional as F
+
+from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
+from tools.vqgan.extract_vq import get_model
 
 PAD_TOKEN_ID = torch.LongTensor([CODEBOOK_PAD_TOKEN_ID])
+
 
 class Encoder(torch.nn.Module):
     def __init__(self, model):
@@ -19,7 +21,8 @@ class Encoder(torch.nn.Module):
         _, indices = self.model.quantizer.residual_fsq(z.transpose(-2, -1))
         _, b, l, _ = indices.shape
         return indices.permute(1, 0, 3, 2).contiguous().view(b, -1, l)
-        
+
+
 class Decoder(torch.nn.Module):
     def __init__(self, model):
         super().__init__()
@@ -32,9 +35,22 @@ class Decoder(torch.nn.Module):
         _, quantize_dim, _ = indices.shape
         d_dim = self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.shape[2]
 
-        if quantize_dim < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers:
-            assert self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0., 'quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations'
-            indices = F.pad(indices, (0, self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers - quantize_dim), value = -1)
+        if (
+            quantize_dim
+            < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
+        ):
+            assert (
+                self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0.0
+            ), "quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations"
+            indices = F.pad(
+                indices,
+                (
+                    0,
+                    self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
+                    - quantize_dim,
+                ),
+                value=-1,
+            )
 
         mask = indices == -1
         indices = indices.masked_fill(mask, 0)
@@ -42,12 +58,16 @@ class Decoder(torch.nn.Module):
         all_codes = torch.gather(
             self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.unsqueeze(1),
             dim=2,
-            index=indices.long().permute(2, 0, 1).unsqueeze(-1).repeat(1,1,1,d_dim)
+            index=indices.long().permute(2, 0, 1).unsqueeze(-1).repeat(1, 1, 1, d_dim),
         )
 
-        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.)
+        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.0)
 
-        scales = self.model.quantizer.residual_fsq.rvqs[cur_index].scales.unsqueeze(1).unsqueeze(1)
+        scales = (
+            self.model.quantizer.residual_fsq.rvqs[cur_index]
+            .scales.unsqueeze(1)
+            .unsqueeze(1)
+        )
         all_codes = all_codes * scales
 
         return all_codes
@@ -55,7 +75,9 @@ class Decoder(torch.nn.Module):
     def get_output_from_indices(self, cur_index, indices):
         codes = self.get_codes_from_indices(cur_index, indices)
         codes_summed = codes.sum(dim=0)
-        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(codes_summed)
+        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(
+            codes_summed
+        )
 
     def forward(self, indices) -> torch.Tensor:
         batch_size, _, length = indices.shape
@@ -63,17 +85,20 @@ class Decoder(torch.nn.Module):
         groups = self.model.quantizer.residual_fsq.groups
         dim_per_group = dims // groups
 
-        #indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
+        # indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
         indices = indices.view(batch_size, groups, -1, length).permute(1, 0, 3, 2)
 
-        #z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
+        # z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
         z_q = torch.empty((batch_size, length, dims))
         for i in range(groups):
-            z_q[:,:,i*dim_per_group:(i+1)*dim_per_group] = self.get_output_from_indices(i, indices[i])
+            z_q[:, :, i * dim_per_group : (i + 1) * dim_per_group] = (
+                self.get_output_from_indices(i, indices[i])
+            )
 
         z = self.model.quantizer.upsample(z_q.transpose(1, 2))
         x = self.model.head(z)
         return x
+
 
 def main(firefly_gan_vq_path, llama_path, export_prefix):
     GanModel = get_model("firefly_gan_vq", firefly_gan_vq_path, device="cpu")
@@ -85,34 +110,30 @@ def main(firefly_gan_vq_path, llama_path, export_prefix):
         enc,
         audio_example,
         f"{export_prefix}encoder.onnx",
-        dynamic_axes = {
+        dynamic_axes={
             "audio": [0, 2],
         },
         do_constant_folding=False,
         opset_version=18,
         verbose=False,
         input_names=["audio"],
-        output_names=["prompt"]
+        output_names=["prompt"],
     )
-    
+
     torch.onnx.export(
         dec,
         indices,
         f"{export_prefix}decoder.onnx",
-        dynamic_axes = {
+        dynamic_axes={
             "prompt": [0, 2],
         },
         do_constant_folding=False,
         opset_version=18,
         verbose=False,
         input_names=["prompt"],
-        output_names=["audio"]
+        output_names=["audio"],
     )
 
 
 if __name__ == "__main__":
-    main(
-        "checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth", 
-        None,
-        "test_"
-    )
+    main("checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth", None, "test_")

--- a/tools/export-onnx.py
+++ b/tools/export-onnx.py
@@ -1,10 +1,12 @@
-from tools.vqgan.extract_vq import get_model
-from einx import get_at
-from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
-import torch.nn.functional as F
 import torch
+import torch.nn.functional as F
+from einx import get_at
+
+from fish_speech.conversation import CODEBOOK_PAD_TOKEN_ID
+from tools.vqgan.extract_vq import get_model
 
 PAD_TOKEN_ID = torch.LongTensor([CODEBOOK_PAD_TOKEN_ID])
+
 
 class Encoder(torch.nn.Module):
     def __init__(self, model):
@@ -17,7 +19,8 @@ class Encoder(torch.nn.Module):
         encoded_features = self.model.backbone(mels)
         indices = self.model.quantizer.encode(encoded_features)
         return indices
-        
+
+
 class Decoder(torch.nn.Module):
     def __init__(self, model):
         super().__init__()
@@ -33,26 +36,48 @@ class Decoder(torch.nn.Module):
         # because of quantize dropout, one can pass in indices that are coarse
         # and the network should be able to reconstruct
 
-        if quantize_dim < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers:
-            assert self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0., 'quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations'
-            indices = F.pad(indices, (0, self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers - quantize_dim), value = -1)
+        if (
+            quantize_dim
+            < self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
+        ):
+            assert (
+                self.model.quantizer.residual_fsq.rvqs[cur_index].quantize_dropout > 0.0
+            ), "quantize dropout must be greater than 0 if you wish to reconstruct from a signal with less fine quantizations"
+            indices = F.pad(
+                indices,
+                (
+                    0,
+                    self.model.quantizer.residual_fsq.rvqs[cur_index].num_quantizers
+                    - quantize_dim,
+                ),
+                value=-1,
+            )
 
         # take care of quantizer dropout
 
         mask = indices == -1
-        indices = indices.masked_fill(mask, 0) # have it fetch a dummy code to be masked out later
+        indices = indices.masked_fill(
+            mask, 0
+        )  # have it fetch a dummy code to be masked out later
 
         all_codes = torch.gather(
             self.model.quantizer.residual_fsq.rvqs[cur_index].codebooks.unsqueeze(1),
             dim=2,
-            index=indices.long().permute(2, 0, 1).unsqueeze(-1).repeat(1,1,1,d_dim)   #q, batch_size, frame, dim
+            index=indices.long()
+            .permute(2, 0, 1)
+            .unsqueeze(-1)
+            .repeat(1, 1, 1, d_dim),  # q, batch_size, frame, dim
         )
 
-        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.)
+        all_codes = all_codes.masked_fill(mask.permute(2, 0, 1).unsqueeze(-1), 0.0)
 
         # scale the codes
 
-        scales = self.model.quantizer.residual_fsq.rvqs[cur_index].scales.unsqueeze(1).unsqueeze(1)
+        scales = (
+            self.model.quantizer.residual_fsq.rvqs[cur_index]
+            .scales.unsqueeze(1)
+            .unsqueeze(1)
+        )
         all_codes = all_codes * scales
 
         # if (accept_image_fmap = True) then return shape (quantize, batch, height, width, dimension)
@@ -62,7 +87,9 @@ class Decoder(torch.nn.Module):
     def get_output_from_indices(self, cur_index, indices):
         codes = self.get_codes_from_indices(cur_index, indices)
         codes_summed = codes.sum(dim=0)
-        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(codes_summed)
+        return self.model.quantizer.residual_fsq.rvqs[cur_index].project_out(
+            codes_summed
+        )
 
     def forward(self, indices) -> torch.Tensor:
         batch_size, _, length = indices.shape
@@ -70,20 +97,27 @@ class Decoder(torch.nn.Module):
         groups = self.model.quantizer.residual_fsq.groups
         dim_per_group = dims // groups
 
-        #indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
+        # indices = rearrange(indices, "b (g r) l -> g b l r", g=groups)
         indices = indices.view(batch_size, groups, -1, length).permute(1, 0, 3, 2)
 
-        #z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
+        # z_q = self.model.quantizer.residual_fsq.get_output_from_indices(indices)
         z_q = torch.empty((batch_size, length, dims))
         for i in range(groups):
-            z_q[:,:,i*dim_per_group:(i+1)*dim_per_group] = self.get_output_from_indices(i, indices[i])
+            z_q[:, :, i * dim_per_group : (i + 1) * dim_per_group] = (
+                self.get_output_from_indices(i, indices[i])
+            )
 
         z = self.model.quantizer.upsample(z_q.transpose(1, 2))
         x = self.model.head(z)
         return x
 
+
 def main():
-    GanModel = get_model("firefly_gan_vq", "checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth", device="cpu")
+    GanModel = get_model(
+        "firefly_gan_vq",
+        "checkpoints/pre/firefly-gan-vq-fsq-8x1024-21hz-generator.pth",
+        device="cpu",
+    )
     enc = Encoder(GanModel)
     dec = Decoder(GanModel)
     audio_example = torch.randn(1, 1, 96000)
@@ -91,7 +125,7 @@ def main():
 
     print(dec(indices).shape)
 
-    '''
+    """
     torch.onnx.export(
         enc,
         audio_example,
@@ -105,23 +139,24 @@ def main():
         input_names=["audio"],
         output_names=["prompt"]
     )
-    '''
+    """
 
     torch.onnx.export(
         dec,
         indices,
         "decoder.onnx",
-        dynamic_axes = {
+        dynamic_axes={
             "prompt": [0, 2],
         },
         do_constant_folding=False,
         opset_version=18,
         verbose=False,
         input_names=["prompt"],
-        output_names=["audio"]
+        output_names=["audio"],
     )
 
     print(enc(audio_example).shape)
     print(dec(enc(audio_example)).shape)
+
 
 main()


### PR DESCRIPTION
Fix BUG:
 - tracer of pytorch could not trace any non-torch types, include python builtin types, math.ceil() will cast a scalar tensor to a python builtin scalar, it will become constant in onnx graph and cause error on outputs.