### PR TITLE
docs: adjust the chapter structure to better organize the model downl…

### DIFF
--- a/docs/en/inference.md
+++ b/docs/en/inference.md
@@ -10,14 +10,14 @@ Inference support command line, HTTP API and web UI.
     3. Given a new piece of text, let the model generate the corresponding semantic tokens.
     4. Input the generated semantic tokens into VITS / VQGAN to decode and generate the corresponding voice.
 
-## Command Line Inference
-
+## Download Models
 Download the required `vqgan` and `llama` models from our Hugging Face repository.
 
 ```bash
 huggingface-cli download fishaudio/fish-speech-1.5 --local-dir checkpoints/fish-speech-1.5
 ```
 
+## Command Line Inference
 ### 1. Generate prompt from voice:
 
 !!! note

--- a/docs/ja/inference.md
+++ b/docs/ja/inference.md
@@ -10,14 +10,14 @@
     3. 新しいテキストが与えられた場合、モデルに対応するセマンティックトークンを生成させます。
     4. 生成されたセマンティックトークンをVITS / VQGANに入力してデコードし、対応する音声を生成します。
 
-## コマンドライン推論
-
+## モデルをダウンロード
 必要な`vqgan`および`llama`モデルを Hugging Face リポジトリからダウンロードします。
 
 ```bash
 huggingface-cli download fishaudio/fish-speech-1.5 --local-dir checkpoints/fish-speech-1.5
 ```
 
+## コマンドライン推論
 ### 1. 音声からプロンプトを生成する：
 
 !!! note

--- a/docs/ko/inference.md
+++ b/docs/ko/inference.md
@@ -10,14 +10,14 @@
     3. 새로운 텍스트를 입력하면, 모델이 해당하는 시맨틱 토큰을 생성합니다.
     4. 생성된 시맨틱 토큰을 VITS / VQGAN에 입력하여 음성을 디코딩하고 생성합니다.
 
-## 명령줄 추론
-
+## 모델 다운로드
 필요한 `vqgan` 및 `llama` 모델을 Hugging Face 리포지토리에서 다운로드하세요.
 
 ```bash
 huggingface-cli download fishaudio/fish-speech-1.5 --local-dir checkpoints/fish-speech-1.5
 ```
 
+## 명령줄 추론
 ### 1. 음성에서 프롬프트 생성:
 
 !!! note

--- a/docs/pt/inference.md
+++ b/docs/pt/inference.md
@@ -10,14 +10,14 @@ Suporte para inferência por linha de comando, API HTTP e interface web (WebUI).
     3. Dado um novo trecho de texto, fazer com que o modelo gere os tokens semânticos correspondentes.
     4. Inserir os tokens semânticos gerados no VITS / VQGAN para decodificar e gerar a voz correspondente.
 
-## Inferência por Linha de Comando
-
+## Baixar modelos
 Baixe os modelos `vqgan` e `llama` necessários do nosso repositório Hugging Face.
 
 ```bash
 huggingface-cli download fishaudio/fish-speech-1.5 --local-dir checkpoints/fish-speech-1.5
 ```
 
+## Inferência por Linha de Comando
 ### 1. Gerar prompt a partir da voz:
 
 !!! note

--- a/docs/zh/inference.md
+++ b/docs/zh/inference.md
@@ -10,8 +10,7 @@
     3. 给定一段新文本, 让模型生成对应的语义 token.
     4. 将生成的语义 token 输入 VQGAN 解码, 生成对应的语音.
 
-## 命令行推理
-
+## 下载模型
 从我们的 huggingface 仓库下载所需的 `vqgan` 和 `llama` 模型。
 
 ```bash
@@ -24,6 +23,7 @@ huggingface-cli download fishaudio/fish-speech-1.5 --local-dir checkpoints/fish-
 HF_ENDPOINT=https://hf-mirror.com huggingface-cli download fishaudio/fish-speech-1.5 --local-dir checkpoints/fish-speech-1.5
 ```
 
+## 命令行推理
 ### 1. 从语音生成 prompt:
 
 !!! note


### PR DESCRIPTION
There are three types of inference, all of which require downloading models first.

However, the model downloading step was originally included only in the command-line inference section. To make it clear that this step is shared across all three types of inference, I’ve created a separate section specifically for downloading models.
