### PR TITLE
support ipv6

### DIFF
--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -1,7 +1,6 @@
 import re
 from threading import Lock
 
-
 import pyrootutils
 import uvicorn
 from kui.asgi import (
@@ -101,15 +100,14 @@ class API(ExceptionHandler):
 
 if __name__ == "__main__":
     api = API()
-    
+
     # IPv6 address format is [xxxx:xxxx::xxxx]:port
-    match = re.search(r'\[([^\]]+)\]:(\d+)$', api.args.listen)
+    match = re.search(r"\[([^\]]+)\]:(\d+)$", api.args.listen)
     if match:
-        host, port = match.groups()  # IPv6 
+        host, port = match.groups()  # IPv6
     else:
-        host, port = api.args.listen.split(":")  # IPv4 
-    
-    
+        host, port = api.args.listen.split(":")  # IPv4
+
     uvicorn.run(
         api.app,
         host=host,

--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -1,4 +1,6 @@
+import re
 from threading import Lock
+
 
 import pyrootutils
 import uvicorn
@@ -98,10 +100,16 @@ class API(ExceptionHandler):
 # Instead, it's better to use multiprocessing or independent models per thread.
 
 if __name__ == "__main__":
-
     api = API()
-    host, port = api.args.listen.split(":")
-
+    
+    # IPv6 address format is [xxxx:xxxx::xxxx]:port
+    match = re.search(r'\[([^\]]+)\]:(\d+)$', api.args.listen)
+    if match:
+        host, port = match.groups()  # IPv6 
+    else:
+        host, port = api.args.listen.split(":")  # IPv4 
+    
+    
     uvicorn.run(
         api.app,
         host=host,


### PR DESCRIPTION


**Is this PR adding new feature or fix a BUG?**

Fix BUG. as I think uvicorn is support both v4 and v6, but   `host, port = api.args.listen.split(":")` this line will fail to split v6 host. because there are many `:` in ipv6 address. many china user not have public ipv4 but easy to get public ipv6. 

**Is this pull request related to any issue? If yes, please link the issue.**

no

-------
or one regular expression could fix it, I just encounter this problem and try to fix it. 
```python3
pattern = r'(?:\[([^\]]+)\]|([^:]+))?:(\d+)$'
match = re.search(pattern, api.args.listen)
ipv6, ipv4, port = match.groups()
host = ipv6 or ipv4
```
