### PR TITLE
Add method GET on route `/health`

### DIFF
--- a/tools/server/views.py
+++ b/tools/server/views.py
@@ -7,7 +7,7 @@ import numpy as np
 import ormsgpack
 import soundfile as sf
 import torch
-from kui.asgi import Body, HTTPException, JSONResponse, Routes, StreamResponse, request
+from kui.asgi import Body, HTTPException, JSONResponse, Routes, StreamResponse, request, HttpView
 from loguru import logger
 from typing_extensions import Annotated
 
@@ -40,9 +40,15 @@ MAX_NUM_SAMPLES = int(os.getenv("NUM_SAMPLES", 1))
 routes = Routes()
 
 
-@routes.http.post("/v1/health")
-async def health():
-    return JSONResponse({"status": "ok"})
+@routes.http("/v1/health")
+class Health(HttpView):
+    @classmethod
+    async def get(cls):
+        return JSONResponse({"status": "ok"})
+
+    @classmethod
+    async def post(cls):
+        return JSONResponse({"status": "ok"})
 
 
 @routes.http.post("/v1/vqgan/encode")

--- a/tools/server/views.py
+++ b/tools/server/views.py
@@ -7,7 +7,15 @@ import numpy as np
 import ormsgpack
 import soundfile as sf
 import torch
-from kui.asgi import Body, HTTPException, JSONResponse, Routes, StreamResponse, request, HttpView
+from kui.asgi import (
+    Body,
+    HTTPException,
+    HttpView,
+    JSONResponse,
+    Routes,
+    StreamResponse,
+    request,
+)
 from loguru import logger
 from typing_extensions import Annotated
 


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix bug.

**Is this pull request related to any issue? If yes, please link the issue.**

This pull request is not related to any issue.

**Description of the fix:**

The `/health` API endpoint was originally using the `POST` method, which is not ideal for a health check. This PR adds a new `/health` endpoint with the `GET` method while keeping the existing `POST` method for backward compatibility.
