### PR TITLE
Fix: “--api-key” argument in api_server.py does not work

### DIFF
--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -29,7 +29,7 @@ from tools.server.views import routes
 class API(ExceptionHandler):
     def __init__(self):
         self.args = parse_args()
-        
+
         def api_auth(endpoint):
             async def verify(token: Annotated[str, Depends(bearer_auth)]):
                 if token != self.args.api_key:

--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -29,8 +29,7 @@ from tools.server.views import routes
 class API(ExceptionHandler):
     def __init__(self):
         self.args = parse_args()
-        self.routes = routes
-
+        
         def api_auth(endpoint):
             async def verify(token: Annotated[str, Depends(bearer_auth)]):
                 if token != self.args.api_key:
@@ -45,6 +44,12 @@ class API(ExceptionHandler):
             else:
                 return passthrough
 
+        self.routes = Routes(
+            routes,  # keep existing routes
+            http_middlewares=[api_auth],  # apply api_auth middleware
+        )
+
+        # OpenAPIの設定
         self.openapi = OpenAPI(
             Info(
                 {


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.

I think the argument “--api-key” in api_server.py is currently not working.

I checked the source code,
Since the api_auth() method is not used,
I added it to the middleware.
