### PR TITLE
changed weights_only=True to false to override security concerns

### DIFF
--- a/tools/llama/merge_lora.py
+++ b/tools/llama/merge_lora.py
@@ -40,7 +40,7 @@ def merge(lora_config, base_weight, lora_weight, output):
     llama_state_dict = llama_model.state_dict()
     llama_state_dict = {k: v for k, v in llama_state_dict.items() if "lora" not in k}
     llama_state_dict_copy = deepcopy(llama_state_dict)
-    lora_state_dict = torch.load(lora_weight, map_location="cpu")
+    lora_state_dict = torch.load(lora_weight, map_location="cpu", weights_only=False)
 
     if "state_dict" in llama_state_dict:
         llama_state_dict = llama_state_dict["state_dict"]


### PR DESCRIPTION
I had been fine-tuning Fish-speech on my custom Hebrew dataset and while doing so, I encountered a issue that comes with recent pytorch version where `weights_only=True` by default and it was breaking **merge_lora.py** file from working properly. I tested after switching it to False and now it works. 

Would love this is incorporated in the default code so that me and others don't have manually switch it back off. Because it is simply a security reason than being a performance issue.