### PR TITLE
quickfix for api_server

### DIFF
--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -84,6 +84,7 @@ class API(ExceptionHandler):
             mode=self.args.mode,
             device=self.args.device,
             half=self.args.half,
+            asr_enabled=False,
             compile=self.args.compile,
             llama_checkpoint_path=self.args.llama_checkpoint_path,
             decoder_checkpoint_path=self.args.decoder_checkpoint_path,

--- a/tools/server/views.py
+++ b/tools/server/views.py
@@ -34,7 +34,6 @@ from tools.server.api_utils import (
 from tools.server.inference import inference_wrapper as inference
 from tools.server.model_manager import ModelManager
 from tools.server.model_utils import (
-    batch_asr,
     batch_vqgan_decode,
     cached_vqgan_batch_encode,
 )


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

quickfix for api_server.

Issues:

ImportError: cannot import name 'batch_asr' from 'tools.server.model_utils' (fish-speech/tools/server/model_utils.py)

app.state.model_manager = ModelManager(
                              ^^^^^^^^^^^^^
TypeError: ModelManager.__init__() missing 1 required positional argument: 'asr_enabled'
