### PR TITLE
fix: add compatibility check for models without spec_transform attribute

### DIFF
--- a/tools/server/model_utils.py
+++ b/tools/server/model_utils.py
@@ -20,12 +20,10 @@ def batch_encode(model, audios_list: list[bytes]):
         sample_rate = model.spec_transform.sample_rate
     else:
         sample_rate = model.sample_rate
-        
+
     audios: list[torch.Tensor] = [
         (
-            torch.from_numpy(
-                librosa.load(io.BytesIO(audio), sr=sample_rate)[0]
-            )[None]
+            torch.from_numpy(librosa.load(io.BytesIO(audio), sr=sample_rate)[0])[None]
             if isinstance(audio, bytes)
             else audio
         )


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.

**Is this pull request related to any issue? If yes, please link the issue.**

#xxx

Start API server command:
```bash
python -m tools.api_server \
    --listen 0.0.0.0:8080 \
    --llama-checkpoint-path "checkpoints/openaudio-s1-mini" \
    --decoder-checkpoint-path "checkpoints/openaudio-s1-mini/codec.pth" \
    --decoder-config-name modded_dac_vq \
    --compile
```

Requesting `http://localhost:8080/v1/vqgan/encode` will trigger an error:
```bash
Traceback (most recent call last):
  File "/workspace/miniconda/envs/fish-speech/lib/python3.12/site-packages/kui/asgi/exceptions.py", line 27, in wrapper
    return await endpoint()
           ^^^^^^^^^^^^^^^^
  File "/workspace/projects/fish-speech/tools/api_server.py", line 40, in passthrough
    return await endpoint()
           ^^^^^^^^^^^^^^^^
  File "/workspace/miniconda/envs/fish-speech/lib/python3.12/site-packages/kui/asgi/views.py", line 29, in wrapper
    return await function()
           ^^^^^^^^^^^^^^^^
  File "/workspace/miniconda/envs/fish-speech/lib/python3.12/site-packages/kui/asgi/parameters.py", line 119, in callback_with_auto_bound_params
    result = await result
             ^^^^^^^^^^^^
  File "/workspace/projects/fish-speech/tools/server/views.py", line 65, in vqgan_encode
    tokens = cached_vqgan_batch_encode(decoder_model, req.audios)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/miniconda/envs/fish-speech/lib/python3.12/site-packages/cachetools/_cached.py", line 196, in wrapper
    v = func(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/projects/fish-speech/tools/server/model_utils.py", line 52, in cached_vqgan_batch_encode
    return batch_encode(model, audios)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/miniconda/envs/fish-speech/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/miniconda/envs/fish-speech/lib/python3.12/site-packages/torch/amp/autocast_mode.py", line 44, in decorate_autocast
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/projects/fish-speech/tools/server/model_utils.py", line 21, in batch_encode
    librosa.load(io.BytesIO(audio), sr=model.spec_transform.sample_rate)[0]
                                       ^^^^^^^^^^^^^^^^^^^^
  File "/workspace/miniconda/envs/fish-speech/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1940, in __getattr__
    raise AttributeError(
AttributeError: 'DAC' object has no attribute 'spec_transform'
```

The batch_encode function was missing the hasattr check for spec_transform
that is already present in other parts of the codebase (inference_engine).
This caused AttributeError when using DAC models through the API endpoints.

Applied the same compatibility pattern used elsewhere in the project.
