### PR TITLE
change codes_N default save path

### DIFF
--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -610,7 +610,7 @@ def launch_thread_safe_queue(
 @click.option("--half/--no-half", default=False)
 @click.option("--iterative-prompt/--no-iterative-prompt", default=True)
 @click.option("--chunk-length", type=int, default=300)
-@click.option("--output-dir", type=Path, default="temp")
+@click.option("--output-dir", type=Path, default="./")
 def main(
     text: str,
     prompt_text: Optional[tuple[str, ...]],


### PR DESCRIPTION
根据 docs/x/inference.md, 使用命令行推理的时候，第二步从文本生成语义令牌产生的codes_N文件，保存目录应该是当前工作目录，原有代码中是保持到./temp/下，改动md文件需要改动的文件太多了，每种语言都需要更改，所以只改代码中的这一处即可。