### PR TITLE
fix: clarify model weight loading log message

### DIFF
--- a/fish_speech/models/text2semantic/llama.py
+++ b/fish_speech/models/text2semantic/llama.py
@@ -491,7 +491,7 @@ class BaseTransformer(nn.Module):
                     )
 
             err = model.load_state_dict(weights, strict=False, assign=True)
-            logger.info(f"Loaded weights with error: {err}")
+            logger.info(f"Model weights loaded - Status: {err}")
 
         if lora_config is not None:
             setup_lora(model, lora_config)


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

 Fix BUG.

**Is this pull request related to any issue? If yes, please link the issue.**
No related issue. This is a minor log message clarity improvement I discovered while using Fish Speech.

## Problem
While monitoring logs, I noticed a misleading message during model weight loading:
```
fish_speech.models.text2semantic.llama:from_pretrained:498 - Loaded weights with error: <All keys matched successfully>
```

The word **"error"** suggests something went wrong, but the message indicates everything is working perfectly. This creates confusion during debugging.

## Root Cause
PyTorch's `load_state_dict()` returns a `_IncompatibleKeys` NamedTuple that shows:
- `<All keys matched successfully>` when weights load correctly
- Detailed incompatibility info when there are mismatches

The variable name `err` and log message "error:" are misleading since this is status information, not necessarily an error.

## Solution
Changed log message from:
```python
logger.info(f"Loaded weights with error: {err}")
```

To:
```python
logger.info(f"Model weights loaded - Status: {err}")
```

## Impact
**Before (Confusing):**
Loaded weights with error: <All keys matched successfully>

**After (Clear):**
Model weights loaded - Status: <All keys matched successfully>

## Benefits
- Eliminates confusion during log monitoring
- Improves developer experience
- Makes logs more accurate
- No functional changes
