### PR TITLE
Fix Gradio 6.x compatibility: remove show_api parameter from app.laun…

### DIFF
--- a/tools/run_webui.py
+++ b/tools/run_webui.py
@@ -104,4 +104,4 @@ if __name__ == "__main__":
     inference_fct = get_inference_wrapper(inference_engine)
 
     app = build_app(inference_fct, args.theme)
-    app.launch(show_api=True)
+    app.launch()


### PR DESCRIPTION
…ch()

Fixes #1138

Gradio 6.x moved the show_api parameter from the launch() method. This change removes the deprecated parameter to ensure compatibility with Gradio 6.x while maintaining backward compatibility.

The TypeError 'Blocks.launch() got an unexpected keyword argument show_api' has been resolved by removing the parameter from the app.launch() call.

**Is this PR adding new feature or fix a BUG?**

Fix BUG
**Is this pull request related to any issue? If yes, please link the issue.**

#1138