### PR TITLE
fix(server): make uvicorn workers>1 work (factory + spawn for CUDA)

### DIFF
--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -1,4 +1,5 @@
 import json
+import multiprocessing
 import os
 import re
 from argparse import Namespace
@@ -121,6 +122,9 @@ def create_app():
 # Instead, it's better to use multiprocessing or independent models per thread.
 
 if __name__ == "__main__":
+
+    multiprocessing.set_start_method("spawn", force=True)
+
     args = parse_args()
     os.environ[ENV_ARGS_KEY] = json.dumps(vars(args))
 

--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -1,5 +1,8 @@
+import json
+import os
 import re
 from threading import Lock
+from argparse import Namespace
 
 import pyrootutils
 import uvicorn
@@ -25,10 +28,12 @@ from tools.server.exception_handler import ExceptionHandler
 from tools.server.model_manager import ModelManager
 from tools.server.views import routes
 
+ENV_ARGS_KEY = "FISH_API_SERVER_ARGS"
+
 
 class API(ExceptionHandler):
-    def __init__(self):
-        self.args = parse_args()
+    def __init__(self, args: Namespace | None = None):
+        self.args = args or parse_args()
 
         def api_auth(endpoint):
             async def verify(token: Annotated[str, Depends(bearer_auth)]):
@@ -93,6 +98,19 @@ class API(ExceptionHandler):
         logger.info(f"Startup done, listening server at http://{self.args.listen}")
 
 
+def create_app():
+    args_env = os.environ.get(ENV_ARGS_KEY)
+    args = None
+
+    if args_env:
+        try:
+            args = Namespace(**json.loads(args_env))
+        except Exception as exc:
+            logger.warning(f"Failed to load args from {ENV_ARGS_KEY}: {exc}")
+
+    return API(args=args).app
+
+
 # Each worker process created by Uvicorn has its own memory space,
 # meaning that models and variables are not shared between processes.
 # Therefore, any variables (like `llama_queue` or `decoder_model`)
@@ -103,19 +121,21 @@ class API(ExceptionHandler):
 # Instead, it's better to use multiprocessing or independent models per thread.
 
 if __name__ == "__main__":
-    api = API()
+    args = parse_args()
+    os.environ[ENV_ARGS_KEY] = json.dumps(vars(args))
 
     # IPv6 address format is [xxxx:xxxx::xxxx]:port
-    match = re.search(r"\[([^\]]+)\]:(\d+)$", api.args.listen)
+    match = re.search(r"\[([^\]]+)\]:(\d+)$", args.listen)
     if match:
         host, port = match.groups()  # IPv6
     else:
-        host, port = api.args.listen.split(":")  # IPv4
+        host, port = args.listen.split(":")  # IPv4
 
     uvicorn.run(
-        api.app,
+        "tools.api_server:create_app",
         host=host,
         port=int(port),
-        workers=api.args.workers,
+        workers=args.workers,
         log_level="info",
+        factory=True,
     )

--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -1,8 +1,8 @@
 import json
 import os
 import re
-from threading import Lock
 from argparse import Namespace
+from threading import Lock
 
 import pyrootutils
 import uvicorn


### PR DESCRIPTION
FIXES: 
https://github.com/fishaudio/fish-speech/issues/1142
https://github.com/fishaudio/fish-speech/issues/1143

### Bugs sum up
1. On linux, default multiprocessing method is fork(). CUDA ctxs can't be inherited by forked child - when multiple workers try to init CUDA after forking, they crash. Only one worker survives /w uv retries;
2. Got an issues running /w workers > 1 in 1 container, each worker starts as a separate process and imports the module fresh - cli args parsed in `__main__` only exist in the parent process, so workers would miss that config and fall back to defaults/break.

### What I changed

* Set multiprocessing to spawn before starting uv, so each worker starts fresh = no fork = no CUDA init crashes;
* Parent now dumps parsed args to json and stores them in var before starting uv;
* Workers calls the factory, it reads the var, loads the json, and rebuilds the namespace, so every worker gets the same config.

### QA

* Solo-worker - same;
* Multi-workers - config is passed to all workers;
* Tested in Docker with 3 workers on 4090.
