### PR TITLE
fix: add torchaudio 2.9 compatibility for list_audio_backends removal

### DIFF
--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -31,11 +31,22 @@ class ReferenceLoader:
         self.encode_reference: Callable
 
         # Define the torchaudio backend
-        backends = torchaudio.list_audio_backends()
-        if "ffmpeg" in backends:
-            self.backend = "ffmpeg"
-        else:
-            self.backend = "soundfile"
+        # list_audio_backends() was removed in torchaudio 2.9
+        try:
+            backends = torchaudio.list_audio_backends()
+            if "ffmpeg" in backends:
+                self.backend = "ffmpeg"
+            else:
+                self.backend = "soundfile"
+        except AttributeError:
+            # torchaudio 2.9+ removed list_audio_backends()
+            # Try ffmpeg first, fallback to soundfile
+            try:
+                import torchaudio.io._load_audio_fileobj  # noqa: F401
+
+                self.backend = "ffmpeg"
+            except (ImportError, ModuleNotFoundError):
+                self.backend = "soundfile"
 
     def load_by_id(
         self,

--- a/tools/vqgan/extract_vq.py
+++ b/tools/vqgan/extract_vq.py
@@ -23,12 +23,22 @@ OmegaConf.register_new_resolver("eval", eval)
 # This file is used to convert the audio files to text files using the Whisper model.
 # It's mainly used to generate the training data for the VQ model.
 
-backends = torchaudio.list_audio_backends()
+# Determine audio backend - list_audio_backends() was removed in torchaudio 2.9
+try:
+    backends = torchaudio.list_audio_backends()
+    if "ffmpeg" in backends:
+        backend = "ffmpeg"
+    else:
+        backend = "soundfile"
+except AttributeError:
+    # torchaudio 2.9+ removed list_audio_backends()
+    # Try ffmpeg first, fallback to soundfile
+    try:
+        import torchaudio.io._load_audio_fileobj  # Check if ffmpeg backend is available
 
-if "ffmpeg" in backends:
-    backend = "ffmpeg"
-else:
-    backend = "soundfile"
+        backend = "ffmpeg"
+    except (ImportError, ModuleNotFoundError):
+        backend = "soundfile"
 
 RANK = int(os.environ.get("SLURM_PROCID", 0))
 WORLD_SIZE = int(os.environ.get("SLURM_NTASKS", 1))


### PR DESCRIPTION
## Summary
Fix crash on startup with torchaudio 2.9+ due to removed `list_audio_backends()` function.

## Problem
`torchaudio.list_audio_backends()` was deprecated in torchaudio 2.8 and removed in 2.9 (released Oct 2025). Since the project's `pyproject.toml` has unpinned torchaudio dependency, users installing with CUDA 12.8 extras get torchaudio 2.9+, which causes:

```
AttributeError: module 'torchaudio' has no attribute 'list_audio_backends'
```

Affected files:
- `tools/vqgan/extract_vq.py`
- `fish_speech/inference_engine/reference_loader.py`

## Solution
Added try/except to handle both old and new torchaudio versions:
- For torchaudio < 2.9: Uses `list_audio_backends()` as before
- For torchaudio 2.9+: Attempts to detect ffmpeg availability by importing the ffmpeg-related module, falling back to soundfile if unavailable

This maintains backward compatibility while supporting the latest torchaudio.

Fixes #1118