### PR TITLE
fix: apply temperature scaling before top-p filtering in logits_to_probs

### DIFF
--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -63,6 +63,9 @@ def logits_to_probs(
         )
         logits.scatter_(dim=-1, index=previous_tokens, src=score)
 
+    # Apply temperature scaling before top-p filtering
+    logits = logits / torch.clip(temperature, min=1e-5)
+
     # Apply top-p sampling
     sorted_logits, sorted_indices = torch.sort(logits, descending=True)
     cum_probs = torch.cumsum(torch.nn.functional.softmax(sorted_logits, dim=-1), dim=-1)
@@ -72,7 +75,6 @@ def logits_to_probs(
         dim=-1, index=sorted_indices, src=sorted_indices_to_remove
     )
     logits = logits.masked_fill(indices_to_remove, -float("Inf"))
-    logits = logits / torch.clip(temperature, min=1e-5)
 
     probs = torch.nn.functional.softmax(logits, dim=-1)
     return probs


### PR DESCRIPTION
## Summary

- In `logits_to_probs()`, temperature scaling was applied **after** top-p filtering, causing the cumulative probability threshold to operate on the raw (unscaled) logit distribution rather than the temperature-adjusted one
- Moved the temperature division (`logits / temperature`) to **before** the top-p sorting and cumulative sum, so that `top_p` filters based on the correct probability distribution
- With `temperature < 1.0`, the previous order made top-p effectively more restrictive than intended; with `temperature > 1.0`, it was less restrictive

## Details

The standard sampling pipeline order is:

1. Repetition penalty
2. Temperature scaling
3. Top-p (nucleus) filtering
4. Final softmax → sample

Previously, the code ran top-p filtering on the raw logits and only applied temperature afterwards. Since top-p computes `softmax → cumsum` to decide which tokens to keep, it needs to see the temperature-adjusted logits to make the right filtering decisions. Otherwise the `top_p` parameter doesn't behave as users expect when `temperature != 1.0`.

## Test plan

- [ ] Verify that with `temperature=1.0`, behavior is unchanged (temperature scaling is a no-op)
- [ ] Verify that with `temperature < 1.0`, top-p retains fewer tokens than before (correctly more peaked distribution)
- [ ] Verify that with `temperature > 1.0`, top-p retains more tokens than before (correctly flatter distribution)