### PR TITLE
fix: use batch-safe indexing in top-p filtering to support batched logits

### DIFF
--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -67,7 +67,7 @@ def logits_to_probs(
     sorted_logits, sorted_indices = torch.sort(logits, descending=True)
     cum_probs = torch.cumsum(torch.nn.functional.softmax(sorted_logits, dim=-1), dim=-1)
     sorted_indices_to_remove = cum_probs > top_p
-    sorted_indices_to_remove[0] = False  # keep at least one option
+    sorted_indices_to_remove[..., 0] = False  # keep at least one option
     indices_to_remove = sorted_indices_to_remove.scatter(
         dim=-1, index=sorted_indices, src=sorted_indices_to_remove
     )


### PR DESCRIPTION
## Summary

In `logits_to_probs()`, the top-p filtering step uses `sorted_indices_to_remove[0] = False` to ensure at least one token is always kept (never masked out). However, this scalar index `[0]` only addresses the very first element of the tensor — which is correct for a 1-D tensor but breaks for batched (2-D) logits, where it would only protect the first token of the **first** batch element while leaving other batch elements unprotected.

This PR changes the index to `sorted_indices_to_remove[..., 0] = False`, which uses ellipsis indexing to always target the first element along the **last** dimension. This correctly preserves the highest-probability token for every batch element, making the function safe for both 1-D and batched 2-D inputs.

## Changes

- `fish_speech/models/text2semantic/inference.py`: Changed `sorted_indices_to_remove[0]` to `sorted_indices_to_remove[..., 0]` in `logits_to_probs()`

## Test plan

- [x] Verified the change is a single-character semantic fix with no behavioral difference for the existing 1-D usage path
- [ ] For 2-D batched logits, the `[..., 0]` indexing correctly sets the first element of each row to `False`, preserving at least one token per batch element