### PR TITLE
Fix #1142: [BUG] api server doesn’t start with workers > 1 in docker (u

### DIFF
--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -102,9 +102,11 @@ class API(ExceptionHandler):
 # outputs if multiple threads access the same buffers simultaneously.
 # Instead, it's better to use multiprocessing or independent models per thread.
 
-if __name__ == "__main__":
-    api = API()
+# Module-level app instance for uvicorn import string support (required for workers > 1)
+api = API()
+app = api.app
 
+if __name__ == "__main__":
     # IPv6 address format is [xxxx:xxxx::xxxx]:port
     match = re.search(r"\[([^\]]+)\]:(\d+)$", api.args.listen)
     if match:
@@ -112,8 +114,11 @@ if __name__ == "__main__":
     else:
         host, port = api.args.listen.split(":")  # IPv4
 
+    # Uvicorn requires an import string (not an app instance) when workers > 1
+    app_target = "tools.api_server:app" if api.args.workers > 1 else app
+
     uvicorn.run(
-        api.app,
+        app_target,
         host=host,
         port=int(port),
         workers=api.args.workers,


### PR DESCRIPTION
Fixes #1142

## Summary
This PR fixes: [BUG] api server doesn’t start with workers > 1 in docker (uvicorn import string warning)

## Changes
```
tools/api_server.py | 11 ++++++++---
 1 file changed, 8 insertions(+), 3 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*