### PR TITLE
Fix #834: When the 'compile' option is enabled, using uvicorn to start

### DIFF
--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -25,6 +25,11 @@ from fish_speech.tokenizer import IM_END_TOKEN
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
+# Use "spawn" so that Inductor compilation workers do not inherit the parent
+# process state (e.g. an asyncio event loop started by uvicorn), which would
+# otherwise cause them to deadlock when compile=True is used. See #834.
+if hasattr(torch._inductor.config, "worker_start_method"):
+    torch._inductor.config.worker_start_method = "spawn"
 
 if hasattr(torch._inductor.config, "fx_graph_cache"):
     # Experimental feature to reduce compilation times, will be on by default in future


### PR DESCRIPTION
Fixes #834

## Summary
This PR fixes: When the 'compile' option is enabled, using uvicorn to start the Python script will cause blocking during inference.

## Changes
```
fish_speech/models/text2semantic/inference.py | 5 +++++
 1 file changed, 5 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*