### PR TITLE
Fix #1133: how to change the return audio length in streaming mode

### DIFF
--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -506,8 +506,15 @@ def generate_long(
         global_encoded.append(decoded.cpu())
         assert (codes >= 0).all(), f"Negative code found: {codes}"
 
-        yield GenerateResponse(action="sample", codes=codes, text=text)
-        seg_idx += 1
+        # Yield codes in chunks of chunk_length to support streaming
+        if chunk_length > 0 and codes.shape[1] > chunk_length:
+            for i in range(0, codes.shape[1], chunk_length):
+                chunk = codes[:, i : i + chunk_length]
+                yield GenerateResponse(action="sample", codes=chunk, text=text)
+                seg_idx += 1
+        else:
+            yield GenerateResponse(action="sample", codes=codes, text=text)
+            seg_idx += 1
 
         # Force GPU memory cleanup
         del y, decoded, codes


### PR DESCRIPTION
Fixes #1133

## Summary
This PR fixes: how to change the return audio length in streaming mode

## Changes
```
fish_speech/models/text2semantic/inference.py | 11 +++++++++--
 1 file changed, 9 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*