### PR TITLE
Fix #1118: Crash on startup: AttributeError: torchaudio.list_audio_back

### DIFF
--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -31,11 +31,17 @@ class ReferenceLoader:
         self.encode_reference: Callable
 
         # Define the torchaudio backend
-        backends = torchaudio.list_audio_backends()
-        if "ffmpeg" in backends:
-            self.backend = "ffmpeg"
+        if hasattr(torchaudio, "list_audio_backends"):
+            backends = torchaudio.list_audio_backends()
+            self.backend = "ffmpeg" if "ffmpeg" in backends else "soundfile"
         else:
-            self.backend = "soundfile"
+            # torchaudio >= 2.9 removed list_audio_backends(); default to soundfile
+            try:
+                import torchaudio._backend.ffmpeg  # noqa: F401
+
+                self.backend = "ffmpeg"
+            except Exception:
+                self.backend = "soundfile"
 
     def load_by_id(
         self,

--- a/tools/vqgan/extract_vq.py
+++ b/tools/vqgan/extract_vq.py
@@ -23,12 +23,17 @@ OmegaConf.register_new_resolver("eval", eval)
 # This file is used to convert the audio files to text files using the Whisper model.
 # It's mainly used to generate the training data for the VQ model.
 
-backends = torchaudio.list_audio_backends()
-
-if "ffmpeg" in backends:
-    backend = "ffmpeg"
+if hasattr(torchaudio, "list_audio_backends"):
+    backends = torchaudio.list_audio_backends()
+    backend = "ffmpeg" if "ffmpeg" in backends else "soundfile"
 else:
-    backend = "soundfile"
+    # torchaudio >= 2.9 removed list_audio_backends(); default to soundfile
+    try:
+        import torchaudio._backend.ffmpeg  # noqa: F401
+
+        backend = "ffmpeg"
+    except Exception:
+        backend = "soundfile"
 
 RANK = int(os.environ.get("SLURM_PROCID", 0))
 WORLD_SIZE = int(os.environ.get("SLURM_NTASKS", 1))


### PR DESCRIPTION
Fixes #1118

## Summary
This PR fixes: Crash on startup: AttributeError: torchaudio.list_audio_backends (TorchAudio 2.9 removal)

## Changes
```
fish_speech/inference_engine/reference_loader.py | 14 ++++++++++----
 tools/vqgan/extract_vq.py                        | 15 ++++++++++-----
 2 files changed, 20 insertions(+), 9 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*