### PR TITLE
32GB VRAM Docker setup, E2E tests, reference preencode/upload, streaming support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,9 @@ filelists/
 *log
 *.log
 site/
+.pytest_cache/
+memory_metrics.jsonl
+memory_snapshot_*.pickle
 
 # External Tools
 # --------------

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ BASE_URL ?= http://127.0.0.1:$(PORT)
 
 help:
 	@echo "Fish Speech 32GB server and E2E"
-	@echo "  make run-server        - Start API server in Docker"
+	@echo "  make run-server        - Start API server in Docker (COMPILE=0)"
+	@echo "  make run-server COMPILE=1 - Start with torch.compile (warmup 2-10 min)"
 	@echo "  make stop-server       - Stop container"
-	@echo "  make e2e               - E2E smoke (uses reference_id if any)"
+	@echo "  make e2e               - E2E smoke (server must be up)"
 	@echo "  make e2e-memory        - E2E memory (2 TTS requests)"
 	@echo "  make preencode         - Pre-encode WAV+txt to references/"
 	@echo "  make preencode-upload  - Pre-encode and upload to server"
@@ -20,7 +21,7 @@ help:
 	@echo "Override: PORT=8080 PREENCODE_CHECKPOINT=../../checkpoints/s2-pro/codec.pth"
 
 run-server:
-	WORKSPACE_DIR="$(WORKSPACE_DIR)" CHECKPOINTS_DIR="$(CHECKPOINTS_DIR)" PORT="$(PORT)" ./scripts/run_server_32gb.sh
+	WORKSPACE_DIR="$(WORKSPACE_DIR)" CHECKPOINTS_DIR="$(CHECKPOINTS_DIR)" PORT="$(PORT)" COMPILE="$(COMPILE)" ./scripts/run_server_32gb.sh
 
 stop-server:
 	docker rm -f $(CONTAINER) 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+# Fish Speech — 32GB VRAM Docker server and E2E tests
+# Use from repo root. See docs/docker-32gb-rtx5090.md
+
+PORT ?= 8080
+CONTAINER ?= fish-speech
+BASE_URL ?= http://127.0.0.1:$(PORT)
+
+.PHONY: run-server stop-server e2e e2e-memory preencode preencode-upload upload-references test help
+
+help:
+	@echo "Fish Speech 32GB server and E2E"
+	@echo "  make run-server        - Start API server in Docker"
+	@echo "  make stop-server       - Stop container"
+	@echo "  make e2e               - E2E smoke (uses reference_id if any)"
+	@echo "  make e2e-memory        - E2E memory (2 TTS requests)"
+	@echo "  make preencode         - Pre-encode WAV+txt to references/"
+	@echo "  make preencode-upload  - Pre-encode and upload to server"
+	@echo "  make upload-references - Upload existing references/ only"
+	@echo "  make test              - Run pytest"
+	@echo "Override: PORT=8080 PREENCODE_CHECKPOINT=../../checkpoints/s2-pro/codec.pth"
+
+run-server:
+	WORKSPACE_DIR="$(WORKSPACE_DIR)" CHECKPOINTS_DIR="$(CHECKPOINTS_DIR)" PORT="$(PORT)" ./scripts/run_server_32gb.sh
+
+stop-server:
+	docker rm -f $(CONTAINER) 2>/dev/null || true
+
+e2e:
+	PORT="$(PORT)" BASE_URL="$(BASE_URL)" ./scripts/e2e_smoke.sh
+
+e2e-memory:
+	PORT="$(PORT)" BASE_URL="$(BASE_URL)" ./scripts/e2e_memory.sh
+
+preencode:
+	PREENCODE_INPUT_DIR="$(PREENCODE_INPUT_DIR)" PREENCODE_OUTPUT_DIR="$(PREENCODE_OUTPUT_DIR)" \
+	PREENCODE_CHECKPOINT="$(PREENCODE_CHECKPOINT)" PREENCODE_REF_ID="$(PREENCODE_REF_ID)" \
+	./scripts/preencode.sh
+
+preencode-upload:
+	PREENCODE_INPUT_DIR="$(PREENCODE_INPUT_DIR)" PREENCODE_OUTPUT_DIR="$(PREENCODE_OUTPUT_DIR)" \
+	PREENCODE_CHECKPOINT="$(PREENCODE_CHECKPOINT)" PREENCODE_REF_ID="$(PREENCODE_REF_ID)" \
+	UPLOAD=1 SERVER_URL="$(BASE_URL)" ./scripts/preencode.sh
+
+upload-references:
+	PREENCODE_OUTPUT_DIR="$(PREENCODE_OUTPUT_DIR)" BASE_URL="$(BASE_URL)" ./scripts/upload_references.sh
+
+test:
+	uv run pytest tests/ -v --tb=short

--- a/docs/docker-32gb-rtx5090.md
+++ b/docs/docker-32gb-rtx5090.md
@@ -1,0 +1,154 @@
+# Running the API server on 32GB VRAM (e.g. RTX 5090)
+
+Minimal Docker-based setup to run the TTS API server on a single GPU with ~32GB VRAM. The same image and env work on RTX 3090/4090/5090.
+
+## What we did (32GB tuning summary)
+
+- **KV cache cap**: `FISH_CACHE_MAX_SEQ_LEN=384` and `FISH_MAX_NEW_TOKENS_CAP=80` to keep VRAM under ~32GB.
+- **Memory between requests**: LLM `clear_caches()` after each request (KV cache released) plus `gc` / `empty_cache` so the second request does not OOM.
+- **Back-pressure**: LLM and DAC do not run in parallel; codes are passed on CPU to avoid holding extra tensors on GPU.
+- **Debug**: `/v1/debug/memory` returns allocated/reserved/max VRAM; optional `?dump=1` for PyTorch snapshot.
+- **Non-streaming TTS**: Views fixed to consume `engine.inference()` and concatenate segment/final chunks into one WAV.
+- **Repro**: This doc + `scripts/run_server_32gb.sh` + optional `WORKSPACE_DIR` when fish-speech lives inside another repo (e.g. checkpoints in parent).
+
+## Quick start
+
+From the **fish-speech repo root**:
+
+```bash
+# Build image, download checkpoints, start server (no torch.compile; fast startup)
+./scripts/run_server_32gb.sh
+```
+
+- First run: builds the image and downloads `fishaudio/s2-pro` into `checkpoints/s2-pro`.
+- Server listens on **http://127.0.0.1:8080** (override with `PORT=18081 ./scripts/run_server_32gb.sh`).
+
+**Using the Makefile** (from repo root):
+
+```bash
+make run-server          # start server (PORT=8080)
+make stop-server         # stop container
+make e2e                 # smoke: health + TTS streaming/oneshot + memory (server must be up)
+make e2e-memory          # two TTS requests + memory (OOM check)
+make help                # list targets
+```
+
+If fish-speech is inside a parent repo and checkpoints are in the parent:
+
+```bash
+make run-server WORKSPACE_DIR=/path/to/parent CHECKPOINTS_DIR=checkpoints/s2-pro
+```
+
+## With torch.compile (faster inference after warmup)
+
+Warmup runs at startup so the server only reports healthy after compilation. First start can take **several minutes** (2–10+), then requests are fast.
+
+```bash
+COMPILE=1 ./scripts/run_server_32gb.sh
+```
+
+Wait until health returns 200:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/health
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | 8080 | Host port for the API |
+| `CONTAINER` | fish-speech | Docker container name |
+| `COMPILE` | 0 | Set to 1 to enable torch.compile (warmup at startup) |
+| `IMAGE` | fish-speech-webui:cu129 | Docker image to run |
+| `CHECKPOINTS_DIR` | checkpoints/s2-pro | Path to s2-pro checkpoints (relative to repo or `WORKSPACE_DIR`) |
+| `WORKSPACE_DIR` | (unset) | If set, mount this dir as `/workspace` so both repo and checkpoints are visible (e.g. parent repo path). |
+
+## 32GB tuning (already set by the script)
+
+- `FISH_CACHE_MAX_SEQ_LEN=384` — KV cache size (smaller = less VRAM).
+- `FISH_MAX_NEW_TOKENS_CAP=80` — cap on generated tokens per request to avoid OOM.
+- `PYTHONPATH=/workspace` — so the container uses the mounted repo (e.g. your branch).
+- `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` — reduces fragmentation.
+
+## E2E tests
+
+With the server already running:
+
+```bash
+make e2e           # health + streaming TTS + oneshot TTS + /v1/debug/memory; writes to results/e2e/
+make e2e-memory   # two streaming TTS requests + memory before/after (checks VRAM is freed, no OOM)
+```
+
+Or run scripts directly (same env vars as Makefile):
+
+```bash
+PORT=8080 ./scripts/e2e_smoke.sh      # smoke
+PORT=8080 ./scripts/e2e_memory.sh     # two requests + memory
+```
+
+Outputs (WAV + `memory_*.json`) go to `results/e2e/` by default; override with `E2E_OUT_DIR=/path`.
+
+## Manual smoke (curl)
+
+After the server is up:
+
+```bash
+# Health
+curl -s http://127.0.0.1:8080/v1/health
+
+# Streaming TTS (no reference; or use reference_id if you added one)
+curl -X POST http://127.0.0.1:8080/v1/tts \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hello world","streaming":true}' \
+  --output test.wav
+
+# GPU memory stats
+curl -s http://127.0.0.1:8080/v1/debug/memory | jq
+```
+
+### Reference voice (optional)
+
+Without a reference, the server uses the model’s default voice. To clone a specific voice you need a **reference**: a short clean speech recording (about 10–30 seconds) and its **exact transcript** (text that was spoken).
+
+**There is no bundled sample.** Use your own recording (e.g. 10–30 s of yourself reading a paragraph), or any clean speech WAV + transcript (e.g. a sample from [LibriSpeech](https://www.openslr.org/12/) or similar). The WAV should be mono, 44.1 kHz is typical; the `.txt` or `.lab` must match what is said in the audio.
+
+**Two ways to add a reference:**
+
+**1) Pre-encode (offline, recommended for 32GB)** — encodes once so the server doesn’t load full WAV at runtime:
+
+- Put in a folder one or more pairs: `<stem>.wav` + `<stem>.txt` (or `<stem>.lab`). Example: `data/voice_references/en.wav` and `data/voice_references/en.txt`.
+- Run (from repo root, with venv/conda that has fish-speech deps):
+
+  ```bash
+  python tools/preencode_references.py --input-dir ./data/voice_references --output-dir references
+  ```
+
+  This creates `references/en/en.codes.pt` and `references/en/en.lab`. With `--ref-id NAME` all files go under `references/NAME/`.
+- Ensure the server can see `references/` (e.g. same mount as repo, or copy into the container). Then call TTS with `"reference_id": "en"`.
+
+**2) API (upload at runtime)** — server encodes on first use (uses more VRAM for that request):
+
+```bash
+curl -X POST http://127.0.0.1:8080/v1/references/add \
+  -F "id=my_voice" \
+  -F "audio=@/path/to/recording.wav" \
+  -F "text=Exact transcript of what is said in the audio."
+```
+
+- List IDs: `curl -s http://127.0.0.1:8080/v1/references/list`
+- TTS with this voice: include `"reference_id": "my_voice"` in the JSON body of `POST /v1/tts`.
+
+## Logs
+
+```bash
+docker logs -f fish-speech
+```
+
+## Stopping
+
+```bash
+make stop-server
+# or
+docker rm -f fish-speech
+```

--- a/fish_speech/inference_engine/__init__.py
+++ b/fish_speech/inference_engine/__init__.py
@@ -61,7 +61,9 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             return {
                 "vram_alloc_gb": round(torch.cuda.memory_allocated() / (1024**3), 2),
                 "vram_reserved_gb": round(torch.cuda.memory_reserved() / (1024**3), 2),
-                "vram_max_alloc_gb": round(torch.cuda.max_memory_allocated() / (1024**3), 2),
+                "vram_max_alloc_gb": round(
+                    torch.cuda.max_memory_allocated() / (1024**3), 2
+                ),
             }
 
         def _mark(event: str, **extra) -> None:
@@ -87,7 +89,9 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             ref_id = req.reference_id
             prompt_tokens, prompt_texts = [], []
             if ref_id is not None:
-                prompt_tokens, prompt_texts = self.load_by_id(ref_id, req.use_memory_cache)
+                prompt_tokens, prompt_texts = self.load_by_id(
+                    ref_id, req.use_memory_cache
+                )
                 _mark("ref_loaded", mode="id")
             elif req.references:
                 prompt_tokens, prompt_texts = self.load_by_hash(
@@ -109,7 +113,9 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             )
             _mark("llama_queued")
             if stream_tokens:
-                logger.info("stream: inference started (token streaming), req={}", req_tag)
+                logger.info(
+                    "stream: inference started (token streaming), req={}", req_tag
+                )
 
             # Get the sample rate from the decoder model
             if hasattr(self.decoder_model, "spec_transform"):
@@ -135,14 +141,29 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             while True:
                 # Get the response from the LLAMA model
                 if stream_tokens:
-                    logger.info("stream: waiting for next chunk from queue, req={}", req_tag)
+                    logger.info(
+                        "stream: waiting for next chunk from queue, req={}", req_tag
+                    )
                 wrapped_result = response_queue.get()
                 _mark("queue_get")
                 if stream_tokens:
-                    action = getattr(wrapped_result.response, "action", None) if hasattr(wrapped_result.response, "action") else None
-                    logger.info("stream: queue_get status={} action={} req={}", wrapped_result.status, action, req_tag)
+                    action = (
+                        getattr(wrapped_result.response, "action", None)
+                        if hasattr(wrapped_result.response, "action")
+                        else None
+                    )
+                    logger.info(
+                        "stream: queue_get status={} action={} req={}",
+                        wrapped_result.status,
+                        action,
+                        req_tag,
+                    )
                 if wrapped_result.status == "error":
-                    logger.error("stream: got error from worker req={} err={}", req_tag, wrapped_result.response)
+                    logger.error(
+                        "stream: got error from worker req={} err={}",
+                        req_tag,
+                        wrapped_result.response,
+                    )
                     _mark("yield_error")
                     yield InferenceResult(
                         code="error",
@@ -169,7 +190,13 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
                             result.codes.shape if result.codes is not None else None,
                             req_tag,
                         )
-                    _mark("decode_vq_start", segment_idx=seg_idx + 1, codes_frames=result.codes.shape[1] if result.codes is not None else 0)
+                    _mark(
+                        "decode_vq_start",
+                        segment_idx=seg_idx + 1,
+                        codes_frames=(
+                            result.codes.shape[1] if result.codes is not None else 0
+                        ),
+                    )
                     try:
                         if result.codes is not None and not result.codes.is_cuda:
                             result = GenerateResponse(
@@ -183,7 +210,11 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
                             logger.exception(
                                 "stream: get_audio_segment FAILED seg_idx={} codes_shape={} req={}: {}",
                                 seg_idx + 1,
-                                result.codes.shape if result.codes is not None else None,
+                                (
+                                    result.codes.shape
+                                    if result.codes is not None
+                                    else None
+                                ),
                                 req_tag,
                                 seg_err,
                             )
@@ -191,7 +222,12 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
                     seg_idx += 1
                     _mark("segment_decoded", segment_idx=seg_idx, samples=len(segment))
                     if stream_tokens:
-                        logger.info("stream: segment_decoded seg_idx={} samples={} req={}", seg_idx, len(segment), req_tag)
+                        logger.info(
+                            "stream: segment_decoded seg_idx={} samples={} req={}",
+                            seg_idx,
+                            len(segment),
+                            req_tag,
+                        )
 
                     if req.streaming:
                         _mark("yield_segment", segment_idx=seg_idx)
@@ -207,7 +243,11 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
                         torch.cuda.empty_cache()
                 else:
                     if stream_tokens:
-                        logger.info("stream: got_next (end of stream), total_segments={} req={}", seg_idx, req_tag)
+                        logger.info(
+                            "stream: got_next (end of stream), total_segments={} req={}",
+                            seg_idx,
+                            req_tag,
+                        )
                     if ack_queue is not None:
                         ack_queue.put(None)
                     _mark("got_next")
@@ -228,7 +268,9 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
                 yield InferenceResult(
                     code="error",
                     audio=None,
-                    error=RuntimeError("No audio generated, please check the input text."),
+                    error=RuntimeError(
+                        "No audio generated, please check the input text."
+                    ),
                 )
             else:
                 audio = np.concatenate(segments, axis=0)

--- a/fish_speech/inference_engine/__init__.py
+++ b/fish_speech/inference_engine/__init__.py
@@ -1,5 +1,7 @@
 import gc
+import os
 import queue
+import time
 from typing import Generator
 
 import numpy as np
@@ -20,7 +22,6 @@ from fish_speech.utils.schema import ServeTTSRequest
 
 
 class TTSInferenceEngine(ReferenceLoader, VQManager):
-
     def __init__(
         self,
         llama_queue: queue.Queue,
@@ -28,7 +29,6 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
         precision: torch.dtype,
         compile: bool,
     ) -> None:
-
         super().__init__()
 
         self.llama_queue = llama_queue
@@ -36,7 +36,6 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
         self.precision = precision
         self.compile = compile
 
-    @torch.inference_mode()
     def inference(self, req: ServeTTSRequest) -> Generator[InferenceResult, None, None]:
         """
         Main inference function:
@@ -45,112 +44,229 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
         - Decodes the VQ tokens to audio.
         """
 
-        ref_id: str | None = req.reference_id
-        prompt_tokens, prompt_texts = [], []
-        # Load the reference audio and text based on id or hash
-        if ref_id is not None:
-            prompt_tokens, prompt_texts = self.load_by_id(ref_id, req.use_memory_cache)
+        profile = os.getenv("FISH_PROFILE_INFERENCE", "0") in {
+            "1",
+            "true",
+            "TRUE",
+            "yes",
+            "YES",
+        }
+        req_tag = hex(id(req))[-6:]
+        t_start = time.perf_counter()
+        t_prev = t_start
 
-        elif req.references:
-            prompt_tokens, prompt_texts = self.load_by_hash(
-                req.references, req.use_memory_cache
+        def _vram_gb() -> dict:
+            if not torch.cuda.is_available():
+                return {}
+            return {
+                "vram_alloc_gb": round(torch.cuda.memory_allocated() / (1024**3), 2),
+                "vram_reserved_gb": round(torch.cuda.memory_reserved() / (1024**3), 2),
+                "vram_max_alloc_gb": round(torch.cuda.max_memory_allocated() / (1024**3), 2),
+            }
+
+        def _mark(event: str, **extra) -> None:
+            nonlocal t_prev
+            if not profile:
+                return
+            now = time.perf_counter()
+            delta_ms = (now - t_prev) * 1000.0
+            total_ms = (now - t_start) * 1000.0
+            t_prev = now
+            vram = _vram_gb()
+            details = " ".join(f"{k}={v}" for k, v in (*vram.items(), *extra.items()))
+            logger.info(
+                "inference_timing req={} event={} delta_ms={:.1f} total_ms={:.1f} {}",
+                req_tag,
+                event,
+                delta_ms,
+                total_ms,
+                details,
             )
 
-        # Set the random seed if provided
-        if req.seed is not None:
-            set_seed(req.seed)
-            logger.warning(f"set seed: {req.seed}")
+        try:
+            ref_id = req.reference_id
+            prompt_tokens, prompt_texts = [], []
+            if ref_id is not None:
+                prompt_tokens, prompt_texts = self.load_by_id(ref_id, req.use_memory_cache)
+                _mark("ref_loaded", mode="id")
+            elif req.references:
+                prompt_tokens, prompt_texts = self.load_by_hash(
+                    req.references, req.use_memory_cache
+                )
+                _mark("ref_loaded", mode="hash", refs=len(req.references))
 
-        # Get the symbolic tokens from the LLAMA model
-        response_queue = self.send_Llama_request(req, prompt_tokens, prompt_texts)
+            # Set the random seed if provided
+            if req.seed is not None:
+                set_seed(req.seed)
+                logger.warning(f"set seed: {req.seed}")
 
-        # Get the sample rate from the decoder model
-        if hasattr(self.decoder_model, "spec_transform"):
-            sample_rate = self.decoder_model.spec_transform.sample_rate
-        else:
-            sample_rate = self.decoder_model.sample_rate
-
-        # If streaming, send the header
-        if req.streaming:
-            yield InferenceResult(
-                code="header",
-                audio=(
-                    sample_rate,
-                    np.array(wav_chunk_header(sample_rate=sample_rate)),
-                ),
-                error=None,
+            # Get the symbolic tokens from the LLAMA model
+            stream_tokens = getattr(req, "stream_tokens", False) or req.streaming
+            # Back-pressure: worker waits for ack after each chunk so DAC decode and LLM don't run on GPU concurrently (avoids OOM on 32 GB).
+            ack_queue = queue.Queue() if stream_tokens else None
+            response_queue = self.send_Llama_request(
+                req, prompt_tokens, prompt_texts, req_tag=req_tag, ack_queue=ack_queue
             )
+            _mark("llama_queued")
+            if stream_tokens:
+                logger.info("stream: inference started (token streaming), req={}", req_tag)
 
-        segments = []
+            # Get the sample rate from the decoder model
+            if hasattr(self.decoder_model, "spec_transform"):
+                sample_rate = self.decoder_model.spec_transform.sample_rate
+            else:
+                sample_rate = self.decoder_model.sample_rate
 
-        while True:
-            # Get the response from the LLAMA model
-            wrapped_result: WrappedGenerateResponse = response_queue.get()
-            if wrapped_result.status == "error":
+            # If streaming, send the header
+            if req.streaming:
+                _mark("yield_header")
+                yield InferenceResult(
+                    code="header",
+                    audio=(
+                        sample_rate,
+                        np.array(wav_chunk_header(sample_rate=sample_rate)),
+                    ),
+                    error=None,
+                )
+
+            segments = []
+            seg_idx = 0
+
+            while True:
+                # Get the response from the LLAMA model
+                if stream_tokens:
+                    logger.info("stream: waiting for next chunk from queue, req={}", req_tag)
+                wrapped_result = response_queue.get()
+                _mark("queue_get")
+                if stream_tokens:
+                    action = getattr(wrapped_result.response, "action", None) if hasattr(wrapped_result.response, "action") else None
+                    logger.info("stream: queue_get status={} action={} req={}", wrapped_result.status, action, req_tag)
+                if wrapped_result.status == "error":
+                    logger.error("stream: got error from worker req={} err={}", req_tag, wrapped_result.response)
+                    _mark("yield_error")
+                    yield InferenceResult(
+                        code="error",
+                        audio=None,
+                        error=(
+                            wrapped_result.response
+                            if isinstance(wrapped_result.response, Exception)
+                            else Exception("Unknown error")
+                        ),
+                    )
+                    break
+
+                if not isinstance(wrapped_result.response, GenerateResponse):
+                    raise TypeError(
+                        "Expected GenerateResponse, got {type(wrapped_result.response).__name__}"
+                    )
+
+                result = wrapped_result.response
+                if result.action != "next":
+                    if stream_tokens:
+                        logger.info(
+                            "stream: decoding segment seg_idx={} codes_shape={} req={}",
+                            seg_idx + 1,
+                            result.codes.shape if result.codes is not None else None,
+                            req_tag,
+                        )
+                    _mark("decode_vq_start", segment_idx=seg_idx + 1, codes_frames=result.codes.shape[1] if result.codes is not None else 0)
+                    try:
+                        if result.codes is not None and not result.codes.is_cuda:
+                            result = GenerateResponse(
+                                result.action,
+                                result.codes.to(self.decoder_model.device),
+                                getattr(result, "text", None),
+                            )
+                        segment = self.get_audio_segment(result)
+                    except Exception as seg_err:
+                        if stream_tokens:
+                            logger.exception(
+                                "stream: get_audio_segment FAILED seg_idx={} codes_shape={} req={}: {}",
+                                seg_idx + 1,
+                                result.codes.shape if result.codes is not None else None,
+                                req_tag,
+                                seg_err,
+                            )
+                        raise
+                    seg_idx += 1
+                    _mark("segment_decoded", segment_idx=seg_idx, samples=len(segment))
+                    if stream_tokens:
+                        logger.info("stream: segment_decoded seg_idx={} samples={} req={}", seg_idx, len(segment), req_tag)
+
+                    if req.streaming:
+                        _mark("yield_segment", segment_idx=seg_idx)
+                        yield InferenceResult(
+                            code="segment",
+                            audio=(sample_rate, segment),
+                            error=None,
+                        )
+                    if ack_queue is not None:
+                        ack_queue.put(None)
+                    segments.append(segment)
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                else:
+                    if stream_tokens:
+                        logger.info("stream: got_next (end of stream), total_segments={} req={}", seg_idx, req_tag)
+                    if ack_queue is not None:
+                        ack_queue.put(None)
+                    _mark("got_next")
+                    break
+
+            # Clean up the memory so next request starts near baseline (~14 GB); otherwise second request OOMs on 32 GB.
+            if torch.cuda.is_available():
+                wrapped_result = None
+                result = None
+                gc.collect()
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+                gc.collect()
+                torch.cuda.empty_cache()
+
+            if len(segments) == 0:
+                _mark("yield_error_empty")
                 yield InferenceResult(
                     code="error",
                     audio=None,
-                    error=(
-                        wrapped_result.response
-                        if isinstance(wrapped_result.response, Exception)
-                        else Exception("Unknown error")
-                    ),
+                    error=RuntimeError("No audio generated, please check the input text."),
                 )
-                break
-
-            # Check the response type
-            if not isinstance(wrapped_result.response, GenerateResponse):
-                raise TypeError(
-                    "Expected GenerateResponse, got {type(wrapped_result.response).__name__}"
-                )
-
-            result: GenerateResponse = wrapped_result.response
-            if result.action != "next":
-                segment = self.get_audio_segment(result)
-
-                if req.streaming:  # Used only by the API server
-                    yield InferenceResult(
-                        code="segment",
-                        audio=(sample_rate, segment),
-                        error=None,
-                    )
-                segments.append(segment)
             else:
-                break
+                audio = np.concatenate(segments, axis=0)
+                _mark("yield_final", total_samples=len(audio), segments=len(segments))
+                yield InferenceResult(
+                    code="final",
+                    audio=(sample_rate, audio),
+                    error=None,
+                )
 
-        # Clean up the memory
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            gc.collect()
-
-        # Edge case: no audio generated
-        if len(segments) == 0:
-            yield InferenceResult(
-                code="error",
-                audio=None,
-                error=RuntimeError("No audio generated, please check the input text."),
-            )
-        else:
-            # Streaming or not, return the final audio
-            audio = np.concatenate(segments, axis=0)
-            yield InferenceResult(
-                code="final",
-                audio=(sample_rate, audio),
-                error=None,
-            )
-
-        return None
+            return None
+        finally:
+            # When generator is closed (client done), try to free VRAM again so next request does not OOM.
+            if torch.cuda.is_available():
+                gc.collect()
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+                gc.collect()
+                torch.cuda.empty_cache()
 
     def send_Llama_request(
-        self, req: ServeTTSRequest, prompt_tokens: list, prompt_texts: list
+        self,
+        req: ServeTTSRequest,
+        prompt_tokens: list,
+        prompt_texts: list,
+        req_tag: str,
+        ack_queue: queue.Queue | None = None,
     ) -> queue.Queue:
         """
         Send a request to the LLAMA model to generate the symbolic tokens.
         """
 
         # Prepare the request
+        # When streaming API is used, enable token-level streaming for low TTFA
+        stream_tokens = getattr(req, "stream_tokens", False) or req.streaming
         request = dict(
             device=self.decoder_model.device,
+            req_tag=req_tag,
             max_new_tokens=req.max_new_tokens,
             text=req.text,
             top_p=req.top_p,
@@ -161,6 +277,9 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             chunk_length=req.chunk_length,
             prompt_tokens=prompt_tokens,
             prompt_text=prompt_texts,
+            stream_tokens=stream_tokens,
+            stream_chunk_size=getattr(req, "stream_chunk_size", 20),
+            ack_queue=ack_queue,
         )
 
         # Create a queue to get the response
@@ -188,5 +307,5 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             # Decode the symbolic tokens to audio
             segment = self.decode_vq_tokens(codes=result.codes)
 
-        # Convert the audio to numpy
-        return segment.float().cpu().numpy()
+        # Convert the audio to numpy (detach: inference path has no grad, but we no longer use inference_mode)
+        return segment.float().detach().cpu().numpy()

--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -42,27 +42,51 @@ class ReferenceLoader:
         id: str,
         use_cache: Literal["on", "off"],
     ) -> Tuple:
-        # Load the references audio and text by id
+        # Load the references audio and text by id.
+        # Each reference can be: (a) .wav + .lab → encode at load, or (b) .codes.pt + .lab → load pre-encoded (no encoder run).
         ref_folder = Path("references") / id
         ref_folder.mkdir(parents=True, exist_ok=True)
         ref_audios = list_files(
             ref_folder, AUDIO_EXTENSIONS, recursive=True, sort=False
         )
+        ref_codes = list(ref_folder.glob("*.codes.pt"))
+        # .codes.pt filename stem is "en.codes" (Path.stem); we want logical stem "en" for en.lab / en.codes.pt
+        def _stem_for_codes(p: Path) -> str:
+            s = p.stem
+            return s.removesuffix(".codes") if s.endswith(".codes") else s
+        stems = {p.stem for p in ref_audios} | {_stem_for_codes(p) for p in ref_codes}
+        stems = sorted(stems)
 
         if use_cache == "off" or id not in self.ref_by_id:
-            # If the references are not already loaded, encode them
-            prompt_tokens = [
-                self.encode_reference(
-                    # decoder_model=self.decoder_model,
-                    reference_audio=audio_to_bytes(str(ref_audio)),
-                    enable_reference_audio=True,
+            prompt_tokens = []
+            prompt_texts = []
+            for stem in stems:
+                lab_path = ref_folder / f"{stem}.lab"
+                codes_path = ref_folder / f"{stem}.codes.pt"
+                audio_path = next(
+                    (ref_folder / f"{stem}{ext}" for ext in AUDIO_EXTENSIONS if (ref_folder / f"{stem}{ext}").exists()),
+                    None,
                 )
-                for ref_audio in ref_audios
-            ]
-            prompt_texts = [
-                read_ref_text(str(ref_audio.with_suffix(".lab")))
-                for ref_audio in ref_audios
-            ]
+                if not lab_path.exists():
+                    logger.warning("Reference stem {} missing .lab, skipping", stem)
+                    continue
+                prompt_texts.append(read_ref_text(str(lab_path)))
+                if codes_path.exists():
+                    # Pre-encoded: load from disk (no encoder run). File must be tensor shape (num_codebooks, T) from DAC encode.
+                    # map_location="cpu" = put tensor in RAM (worker will .to(device) later). Loading to GPU here would save one tiny copy but is negligible for KB-sized tensors.
+                    loaded = torch.load(codes_path, map_location="cpu", weights_only=True)
+                    prompt_tokens.append(loaded if isinstance(loaded, torch.Tensor) else loaded[0])
+                    logger.info("Loaded pre-encoded reference {} from {}", stem, codes_path.name)
+                elif audio_path is not None:
+                    prompt_tokens.append(
+                        self.encode_reference(
+                            reference_audio=audio_to_bytes(str(audio_path)),
+                            enable_reference_audio=True,
+                        )
+                    )
+                else:
+                    logger.warning("Reference stem {} has .lab but no .codes.pt or audio, skipping", stem)
+                    prompt_texts.pop()
             self.ref_by_id[id] = (prompt_tokens, prompt_texts)
 
         else:
@@ -163,6 +187,46 @@ class ReferenceLoader:
                 valid_ids.append(ref_dir.name)
 
         return sorted(valid_ids)
+
+    def add_reference_encoded(
+        self, id: str, codes_bytes: bytes, lab_text: str, stem: str | None = None
+    ) -> Literal["created", "updated", "unchanged"]:
+        """
+        Add or update a pre-encoded reference (e.g. from preencode_references.py).
+        Writes references/<id>/<stem>.codes.pt and <stem>.lab (stem defaults to id). Skips if hash matches.
+        """
+        import re
+
+        if not re.match(r"^[a-zA-Z0-9\-_ ]+$", id):
+            raise ValueError(
+                "Reference ID contains invalid characters. Only alphanumeric, hyphens, underscores, and spaces are allowed."
+            )
+        if len(id) > 255:
+            raise ValueError("Reference ID is too long. Maximum length is 255 characters.")
+        stem = stem or id
+        if not re.match(r"^[a-zA-Z0-9\-_ ]+$", stem):
+            raise ValueError("Stem contains invalid characters.")
+
+        ref_dir = Path("references") / id
+        payload = codes_bytes + lab_text.encode("utf-8")
+        content_hash = sha256(payload).hexdigest()
+        hash_file = ref_dir / f".{stem}.hash"
+
+        if ref_dir.exists() and hash_file.exists():
+            if hash_file.read_text(encoding="utf-8").strip() == content_hash:
+                logger.info("Reference %s/%s unchanged (hash match), skip write", id, stem)
+                return "unchanged"
+
+        existed_before = ref_dir.exists() and (ref_dir / f"{stem}.codes.pt").exists()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        (ref_dir / f"{stem}.codes.pt").write_bytes(codes_bytes)
+        (ref_dir / f"{stem}.lab").write_text(lab_text, encoding="utf-8")
+        hash_file.write_text(content_hash, encoding="utf-8")
+        if id in self.ref_by_id:
+            del self.ref_by_id[id]
+        status = "updated" if existed_before else "created"
+        logger.info("Reference %s/%s %s", id, stem, status)
+        return status
 
     def add_reference(self, id: str, wav_file_path: str, reference_text: str) -> None:
         """

--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -50,10 +50,12 @@ class ReferenceLoader:
             ref_folder, AUDIO_EXTENSIONS, recursive=True, sort=False
         )
         ref_codes = list(ref_folder.glob("*.codes.pt"))
+
         # .codes.pt filename stem is "en.codes" (Path.stem); we want logical stem "en" for en.lab / en.codes.pt
         def _stem_for_codes(p: Path) -> str:
             s = p.stem
             return s.removesuffix(".codes") if s.endswith(".codes") else s
+
         stems = {p.stem for p in ref_audios} | {_stem_for_codes(p) for p in ref_codes}
         stems = sorted(stems)
 
@@ -64,7 +66,11 @@ class ReferenceLoader:
                 lab_path = ref_folder / f"{stem}.lab"
                 codes_path = ref_folder / f"{stem}.codes.pt"
                 audio_path = next(
-                    (ref_folder / f"{stem}{ext}" for ext in AUDIO_EXTENSIONS if (ref_folder / f"{stem}{ext}").exists()),
+                    (
+                        ref_folder / f"{stem}{ext}"
+                        for ext in AUDIO_EXTENSIONS
+                        if (ref_folder / f"{stem}{ext}").exists()
+                    ),
                     None,
                 )
                 if not lab_path.exists():
@@ -74,9 +80,15 @@ class ReferenceLoader:
                 if codes_path.exists():
                     # Pre-encoded: load from disk (no encoder run). File must be tensor shape (num_codebooks, T) from DAC encode.
                     # map_location="cpu" = put tensor in RAM (worker will .to(device) later). Loading to GPU here would save one tiny copy but is negligible for KB-sized tensors.
-                    loaded = torch.load(codes_path, map_location="cpu", weights_only=True)
-                    prompt_tokens.append(loaded if isinstance(loaded, torch.Tensor) else loaded[0])
-                    logger.info("Loaded pre-encoded reference {} from {}", stem, codes_path.name)
+                    loaded = torch.load(
+                        codes_path, map_location="cpu", weights_only=True
+                    )
+                    prompt_tokens.append(
+                        loaded if isinstance(loaded, torch.Tensor) else loaded[0]
+                    )
+                    logger.info(
+                        "Loaded pre-encoded reference {} from {}", stem, codes_path.name
+                    )
                 elif audio_path is not None:
                     prompt_tokens.append(
                         self.encode_reference(
@@ -85,7 +97,10 @@ class ReferenceLoader:
                         )
                     )
                 else:
-                    logger.warning("Reference stem {} has .lab but no .codes.pt or audio, skipping", stem)
+                    logger.warning(
+                        "Reference stem {} has .lab but no .codes.pt or audio, skipping",
+                        stem,
+                    )
                     prompt_texts.pop()
             self.ref_by_id[id] = (prompt_tokens, prompt_texts)
 
@@ -202,7 +217,9 @@ class ReferenceLoader:
                 "Reference ID contains invalid characters. Only alphanumeric, hyphens, underscores, and spaces are allowed."
             )
         if len(id) > 255:
-            raise ValueError("Reference ID is too long. Maximum length is 255 characters.")
+            raise ValueError(
+                "Reference ID is too long. Maximum length is 255 characters."
+            )
         stem = stem or id
         if not re.match(r"^[a-zA-Z0-9\-_ ]+$", stem):
             raise ValueError("Stem contains invalid characters.")
@@ -214,7 +231,9 @@ class ReferenceLoader:
 
         if ref_dir.exists() and hash_file.exists():
             if hash_file.read_text(encoding="utf-8").strip() == content_hash:
-                logger.info("Reference %s/%s unchanged (hash match), skip write", id, stem)
+                logger.info(
+                    "Reference %s/%s unchanged (hash match), skip write", id, stem
+                )
                 return "unchanged"
 
         existed_before = ref_dir.exists() and (ref_dir / f"{stem}.codes.pt").exists()

--- a/fish_speech/inference_engine/vq_manager.py
+++ b/fish_speech/inference_engine/vq_manager.py
@@ -34,9 +34,7 @@ class VQManager:
             # Keep audio on CPU; run encoder on CPU to avoid OOM (encoder on long ref
             # can use ~14+ GB GPU and we're already near 16 GB after warmup).
             audios = torch.from_numpy(reference_audio_content)[None, None, :]
-            audio_lengths = torch.tensor(
-                [audios.shape[2]], dtype=torch.long
-            )
+            audio_lengths = torch.tensor([audios.shape[2]], dtype=torch.long)
             logger.info(
                 f"Loaded audio with {audios.shape[2] / sample_rate:.2f} seconds"
             )
@@ -48,11 +46,15 @@ class VQManager:
                     torch.cuda.empty_cache()
                     self.decoder_model.to("cpu")
                     try:
-                        prompt_tokens = self.decoder_model.encode(audios, audio_lengths)[0][0]
+                        prompt_tokens = self.decoder_model.encode(
+                            audios, audio_lengths
+                        )[0][0]
                     finally:
                         self.decoder_model.to(device)
                 else:
-                    prompt_tokens = self.decoder_model.encode(audios, audio_lengths)[0][0]
+                    prompt_tokens = self.decoder_model.encode(audios, audio_lengths)[0][
+                        0
+                    ]
                 logger.info("Encoded prompt: {}", prompt_tokens.shape)
             else:
                 raise ValueError(f"Unknown model type: {type(self.decoder_model)}")

--- a/fish_speech/inference_engine/vq_manager.py
+++ b/fish_speech/inference_engine/vq_manager.py
@@ -14,7 +14,8 @@ class VQManager:
         self.load_audio: Callable
 
     def decode_vq_tokens(self, codes):
-        logger.info(f"VQ features: {codes.shape}")
+        chunk_len = codes.shape[1] if codes.dim() >= 2 else 0
+        logger.info("VQ features: {} (stream chunk={})", codes.shape, chunk_len)
 
         if isinstance(self.decoder_model, DAC):
             return self.decoder_model.from_indices(codes[None])[0].squeeze()
@@ -30,20 +31,29 @@ class VQManager:
                 sample_rate = self.decoder_model.sample_rate
             reference_audio_content = self.load_audio(reference_audio, sample_rate)
 
-            audios = torch.from_numpy(reference_audio_content).to(
-                self.decoder_model.device
-            )[None, None, :]
+            # Keep audio on CPU; run encoder on CPU to avoid OOM (encoder on long ref
+            # can use ~14+ GB GPU and we're already near 16 GB after warmup).
+            audios = torch.from_numpy(reference_audio_content)[None, None, :]
             audio_lengths = torch.tensor(
-                [audios.shape[2]], device=self.decoder_model.device, dtype=torch.long
+                [audios.shape[2]], dtype=torch.long
             )
             logger.info(
                 f"Loaded audio with {audios.shape[2] / sample_rate:.2f} seconds"
             )
 
-            # VQ Encoder
             if isinstance(self.decoder_model, DAC):
-                prompt_tokens = self.decoder_model.encode(audios, audio_lengths)[0][0]
-                logger.info(f"Encoded prompt: {prompt_tokens.shape}")
+                device = getattr(self.decoder_model, "device", None)
+                on_cuda = device is not None and str(device).startswith("cuda")
+                if on_cuda:
+                    torch.cuda.empty_cache()
+                    self.decoder_model.to("cpu")
+                    try:
+                        prompt_tokens = self.decoder_model.encode(audios, audio_lengths)[0][0]
+                    finally:
+                        self.decoder_model.to(device)
+                else:
+                    prompt_tokens = self.decoder_model.encode(audios, audio_lengths)[0][0]
+                logger.info("Encoded prompt: {}", prompt_tokens.shape)
             else:
                 raise ValueError(f"Unknown model type: {type(self.decoder_model)}")
         else:

--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -36,6 +36,7 @@ def _to_normal_tensor(t: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
     with torch.inference_mode(False):
         return t.detach().cpu().clone().to(t.device)
 
+
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
@@ -249,7 +250,11 @@ def decode_n_tokens(
         dtype=torch.int,
         device=cur_token.device,
     )
-    previous_tokens = cast(torch.Tensor, _to_normal_tensor(_prev_zeros)) if need_normal_state else _prev_zeros
+    previous_tokens = (
+        cast(torch.Tensor, _to_normal_tensor(_prev_zeros))
+        if need_normal_state
+        else _prev_zeros
+    )
     new_tokens: list[torch.Tensor] = []
     # [MODIFIED] Pre-fetch ID for efficiency loop
     im_end_id = model.tokenizer.get_token_id(IM_END_TOKEN)
@@ -267,7 +272,8 @@ def decode_n_tokens(
             # With torch.compile we must use MATH backend so Inductor can fuse attention kernels.
             # Without compile, Flash/Triton is faster. FISH_SDPA_MATH=1 forces MATH when not compiling.
             use_math = compile or (
-                os.environ.get("FISH_SDPA_MATH", "").strip() in ("1", "true", "TRUE", "yes", "YES")
+                os.environ.get("FISH_SDPA_MATH", "").strip()
+                in ("1", "true", "TRUE", "yes", "YES")
             )
             if use_math:
                 with sdpa_kernel(SDPBackend.MATH):
@@ -311,9 +317,16 @@ def decode_n_tokens(
         if need_normal_state:
             next_token = cast(torch.Tensor, _to_normal_tensor(next_token))
             input_pos = cast(torch.Tensor, _to_normal_tensor(input_pos + 1))
-            cur_token = cast(torch.Tensor, _to_normal_tensor(next_token.view(1, model.config.num_codebooks + 1, -1)))
+            cur_token = cast(
+                torch.Tensor,
+                _to_normal_tensor(
+                    next_token.view(1, model.config.num_codebooks + 1, -1)
+                ),
+            )
             # Normalize previous_tokens before inplace; then assign column.
-            previous_tokens = cast(torch.Tensor, _to_normal_tensor(previous_tokens.roll(-1, dims=1)))
+            previous_tokens = cast(
+                torch.Tensor, _to_normal_tensor(previous_tokens.roll(-1, dims=1))
+            )
             prev_col = next_token.view(model.config.num_codebooks + 1, -1)[:, 0]
             previous_tokens[:, -1].copy_(prev_col)
         else:
@@ -321,13 +334,19 @@ def decode_n_tokens(
             input_pos = (input_pos + 1).detach().clone()
             cur_token = next_token.view(1, model.config.num_codebooks + 1, -1).clone()
             previous_tokens = previous_tokens.roll(-1, dims=1)
-            previous_tokens[:, -1] = next_token.view(model.config.num_codebooks + 1, -1)[:, 0].clone()
+            previous_tokens[:, -1] = next_token.view(
+                model.config.num_codebooks + 1, -1
+            )[:, 0].clone()
         new_tokens.append(next_token)
 
         if stream_chunk_size is not None and len(new_tokens) >= stream_chunk_size:
             chunk_out = torch.cat(new_tokens, dim=1).detach().clone()
             if do_stream_log:
-                logger.info("stream: decode_n_tokens yielding chunk shape={} after iter={}", chunk_out.shape, i)
+                logger.info(
+                    "stream: decode_n_tokens yielding chunk shape={} after iter={}",
+                    chunk_out.shape,
+                    i,
+                )
             yield chunk_out
             new_tokens = []
 
@@ -341,7 +360,9 @@ def decode_n_tokens(
     if new_tokens:
         remainder = torch.cat(new_tokens, dim=1).detach().clone()
         if do_stream_log:
-            logger.info("stream: decode_n_tokens yielding remainder shape={}", remainder.shape)
+            logger.info(
+                "stream: decode_n_tokens yielding remainder shape={}", remainder.shape
+            )
         yield remainder
 
 
@@ -401,9 +422,7 @@ def generate(
 
     # Create new tensor each time, but try to reuse memory
     input_pos = torch.arange(0, T, device=device, dtype=torch.long)
-    empty = torch.empty(
-        (codebook_dim, cache_len), dtype=prompt.dtype, device=device
-    )
+    empty = torch.empty((codebook_dim, cache_len), dtype=prompt.dtype, device=device)
     empty[:, :T] = prompt
     seq = empty
 
@@ -701,9 +720,9 @@ def generate_long(
         prompt_tokens = [prompt_tokens]
 
     if use_prompt:
-        assert len(prompt_text) == len(prompt_tokens), (
-            "Prompt text and tokens must have the same length"
-        )
+        assert len(prompt_text) == len(
+            prompt_tokens
+        ), "Prompt text and tokens must have the same length"
 
     if prompt_tokens:
         prompt_tokens = [i.cpu() for i in prompt_tokens]
@@ -895,11 +914,13 @@ def generate_long(
                         )
                     codes_list.append(chunk)
                     chunk_idx += 1
-                logger.info("stream: generate_long finished chunk_idx={} total_chunks={}", chunk_idx, len(codes_list))
+                logger.info(
+                    "stream: generate_long finished chunk_idx={} total_chunks={}",
+                    chunk_idx,
+                    len(codes_list),
+                )
                 codes = (
-                    torch.cat(codes_list, dim=1)[1:, :].clone()
-                    if codes_list
-                    else None
+                    torch.cat(codes_list, dim=1)[1:, :].clone() if codes_list else None
                 )
                 if codes is not None:
                     conversation.append(
@@ -1027,7 +1048,11 @@ def launch_thread_safe_queue(
             checkpoint_path, device, precision, compile=compile
         )
         cache_len = _cache_max_seq_len(model)
-        logger.info("KV cache max_seq_len={} (model max={})", cache_len, model.config.max_seq_len)
+        logger.info(
+            "KV cache max_seq_len={} (model max={})",
+            cache_len,
+            model.config.max_seq_len,
+        )
         with torch.device(device):
             model.setup_caches(
                 max_batch_size=1,
@@ -1047,14 +1072,20 @@ def launch_thread_safe_queue(
 
             kwargs = item.request
             req_tag = str(kwargs.pop("req_tag", "na"))
-            ack_queue = kwargs.pop("ack_queue", None)  # back-pressure: wait for main to finish DAC before next LLM chunk
+            ack_queue = kwargs.pop(
+                "ack_queue", None
+            )  # back-pressure: wait for main to finish DAC before next LLM chunk
             response_queue = item.response_queue
             t_req_start = time.perf_counter()
             t_last_put = t_req_start
             stream_tokens = kwargs.get("stream_tokens", False)
             put_count = 0
             if stream_tokens:
-                logger.info("stream: worker got request req={} stream_chunk_size={}", req_tag, kwargs.get("stream_chunk_size"))
+                logger.info(
+                    "stream: worker got request req={} stream_chunk_size={}",
+                    req_tag,
+                    kwargs.get("stream_chunk_size"),
+                )
 
             try:
                 for chunk in generate_long(
@@ -1110,13 +1141,17 @@ def launch_thread_safe_queue(
                 # Release KV cache and clear allocator so next request starts near baseline (avoids OOM on 32 GB).
                 logger.info("worker: post-request cleanup starting")
                 if torch.cuda.is_available():
-                    before_clear_gb = round(torch.cuda.memory_allocated() / (1024**3), 2)
+                    before_clear_gb = round(
+                        torch.cuda.memory_allocated() / (1024**3), 2
+                    )
                 clear_caches_fn = getattr(model, "clear_caches", None)
                 if clear_caches_fn is not None:
                     try:
                         clear_caches_fn()
                         if torch.cuda.is_available():
-                            after_clear_gb = round(torch.cuda.memory_allocated() / (1024**3), 2)
+                            after_clear_gb = round(
+                                torch.cuda.memory_allocated() / (1024**3), 2
+                            )
                             logger.info(
                                 "worker: clear_caches done alloc before={} GB after={} GB",
                                 before_clear_gb,

--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import queue
 import re
@@ -7,7 +8,7 @@ import traceback
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Literal, Optional, Tuple, Union
+from typing import Callable, Iterator, Literal, Optional, Tuple, Union, cast
 
 import click
 import numpy as np
@@ -22,6 +23,18 @@ from fish_speech.content_sequence import (
 )
 from fish_speech.conversation import Conversation, Message
 from fish_speech.tokenizer import IM_END_TOKEN
+
+
+def _to_normal_tensor(t: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+    """
+    Copy tensor so it is not an inference tensor (AOT fails on inplace into inference tensors).
+    detach().clone() inside inference_mode(False) can still yield inference tensors in some PyTorch
+    versions; roundtrip via CPU forces a new allocation and clears the flag.
+    """
+    if t is None:
+        return None
+    with torch.inference_mode(False):
+        return t.detach().cpu().clone().to(t.device)
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 torch._inductor.config.coordinate_descent_tuning = True
@@ -38,6 +51,20 @@ from fish_speech.models.text2semantic.llama import (
     DualARTransformer,
     NaiveTransformer,
 )
+
+
+def _cache_max_seq_len(model: BaseTransformer) -> int:
+    """
+    Max sequence length used for KV cache and buffers. Tuned for streaming (short turns);
+    512 tokens ~= 41 s audio. Set FISH_CACHE_MAX_SEQ_LEN to override (e.g. 4096 for long form).
+    """
+    default = 512
+    raw = os.environ.get("FISH_CACHE_MAX_SEQ_LEN", str(default))
+    try:
+        n = int(raw)
+    except ValueError:
+        n = default
+    return min(max(1, n), model.config.max_seq_len)
 
 
 def multinomial_sample_one_no_sync(probs_sort):
@@ -193,53 +220,133 @@ def decode_n_tokens(
     audio_masks: torch.Tensor,
     audio_parts: torch.Tensor,
     decode_one_token=decode_one_token_ar,
-):
-    # Rolling window for RAS (Repetition Aware Sampling)
-    previous_tokens = torch.zeros(
+    stream_chunk_size: Optional[int] = None,
+    compile: bool = False,
+) -> Iterator[torch.Tensor]:
+    """
+    Generate tokens autoregressively. When stream_chunk_size is None, yields once
+    with the full tensor (backward compatible). When stream_chunk_size is set, yields
+    every stream_chunk_size tokens for low-TTFA streaming.
+    """
+    need_normal_state = stream_chunk_size is not None
+    # Streaming path: all state must be normal tensors (not inference tensors) so AOT
+    # inplace updates and stateful loop don't explode. Normalize once before loop.
+    if need_normal_state:
+        cur_token = cast(torch.Tensor, _to_normal_tensor(cur_token))
+        input_pos = cast(torch.Tensor, _to_normal_tensor(input_pos))
+        temperature = cast(torch.Tensor, _to_normal_tensor(temperature))
+        top_p = cast(torch.Tensor, _to_normal_tensor(top_p))
+        semantic_logit_bias = cast(torch.Tensor, _to_normal_tensor(semantic_logit_bias))
+        if audio_masks is not None:
+            audio_masks = _to_normal_tensor(audio_masks)
+        if audio_parts is not None:
+            audio_parts = _to_normal_tensor(audio_parts)
+
+    # Rolling window for RAS (Repetition Aware Sampling). Streaming: create as normal
+    # so we never do inplace on an inference tensor.
+    _prev_zeros = torch.zeros(
         (model.config.num_codebooks + 1, RAS_WIN_SIZE),
         dtype=torch.int,
         device=cur_token.device,
     )
-    # Accumulate all generated tokens (the actual output)
-    new_tokens = []
-
+    previous_tokens = cast(torch.Tensor, _to_normal_tensor(_prev_zeros)) if need_normal_state else _prev_zeros
+    new_tokens: list[torch.Tensor] = []
     # [MODIFIED] Pre-fetch ID for efficiency loop
     im_end_id = model.tokenizer.get_token_id(IM_END_TOKEN)
+    do_stream_log = stream_chunk_size is not None
 
     for i in tqdm(range(num_new_tokens)):
-        with sdpa_kernel(SDPBackend.MATH):
-            next_token = decode_one_token(
-                model=model,
-                x=cur_token,
-                input_pos=input_pos,
-                previous_tokens=previous_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                semantic_logit_bias=semantic_logit_bias,
-                audio_masks=audio_masks,
-                audio_parts=audio_parts,
-            ).clone()
+        if do_stream_log and i < 3:
+            logger.info(
+                "stream: decode_n_tokens iter={} cur_token.shape={} input_pos={}",
+                i,
+                cur_token.shape,
+                input_pos.shape,
+            )
+        try:
+            # With torch.compile we must use MATH backend so Inductor can fuse attention kernels.
+            # Without compile, Flash/Triton is faster. FISH_SDPA_MATH=1 forces MATH when not compiling.
+            use_math = compile or (
+                os.environ.get("FISH_SDPA_MATH", "").strip() in ("1", "true", "TRUE", "yes", "YES")
+            )
+            if use_math:
+                with sdpa_kernel(SDPBackend.MATH):
+                    next_token = decode_one_token(
+                        model=model,
+                        x=cur_token,
+                        input_pos=input_pos,
+                        previous_tokens=previous_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        semantic_logit_bias=semantic_logit_bias,
+                        audio_masks=audio_masks,
+                        audio_parts=audio_parts,
+                    ).clone()
+            else:
+                next_token = decode_one_token(
+                    model=model,
+                    x=cur_token,
+                    input_pos=input_pos,
+                    previous_tokens=previous_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    semantic_logit_bias=semantic_logit_bias,
+                    audio_masks=audio_masks,
+                    audio_parts=audio_parts,
+                ).clone()
+        except Exception as e:
+            logger.exception(
+                "stream: decode_n_tokens FAILED at iter={} (cur_token.shape={}): {}",
+                i,
+                cur_token.shape,
+                e,
+            )
+            raise
 
-        input_pos += 1
-        cur_token = next_token.view(1, model.config.num_codebooks + 1, -1)
-        # Roll RAS window left and insert new token at end
-        previous_tokens = previous_tokens.roll(-1, dims=1)
-        previous_tokens[:, -1] = next_token.view(model.config.num_codebooks + 1, -1)[
-            :, 0
-        ]
+        # Streaming: normalize state before any inplace op (AOT fails on inference tensors).
+        # To debug: log tensor.is_inference() before/after (PyTorch 2.5+).
+        # Non-streaming: plain detach/clone.
+        if need_normal_state:
+            next_token = cast(torch.Tensor, _to_normal_tensor(next_token))
+            input_pos = cast(torch.Tensor, _to_normal_tensor(input_pos + 1))
+            cur_token = cast(torch.Tensor, _to_normal_tensor(next_token.view(1, model.config.num_codebooks + 1, -1)))
+            # Normalize previous_tokens before inplace; then assign column.
+            previous_tokens = cast(torch.Tensor, _to_normal_tensor(previous_tokens.roll(-1, dims=1)))
+            prev_col = next_token.view(model.config.num_codebooks + 1, -1)[:, 0]
+            previous_tokens[:, -1].copy_(prev_col)
+        else:
+            next_token = next_token.detach().clone()
+            input_pos = (input_pos + 1).detach().clone()
+            cur_token = next_token.view(1, model.config.num_codebooks + 1, -1).clone()
+            previous_tokens = previous_tokens.roll(-1, dims=1)
+            previous_tokens[:, -1] = next_token.view(model.config.num_codebooks + 1, -1)[:, 0].clone()
         new_tokens.append(next_token)
 
+        if stream_chunk_size is not None and len(new_tokens) >= stream_chunk_size:
+            chunk_out = torch.cat(new_tokens, dim=1).detach().clone()
+            if do_stream_log:
+                logger.info("stream: decode_n_tokens yielding chunk shape={} after iter={}", chunk_out.shape, i)
+            yield chunk_out
+            new_tokens = []
+
         if cur_token[0, 0, -1] == im_end_id:
+            if do_stream_log:
+                logger.info("stream: decode_n_tokens EOS at iter={}", i)
             break
 
     del cur_token
 
-    return torch.cat(new_tokens, dim=1)
+    if new_tokens:
+        remainder = torch.cat(new_tokens, dim=1).detach().clone()
+        if do_stream_log:
+            logger.info("stream: decode_n_tokens yielding remainder shape={}", remainder.shape)
+        yield remainder
 
 
+# Only no_grad(); inference_mode() causes AOT copy-back into inference tensors in streaming.
 @torch.no_grad()
-@torch.inference_mode()
 def generate(
     *,
     model: DualARTransformer,
@@ -259,18 +366,20 @@ def generate(
     T = prompt.size(1)
     prompt = prompt[None].repeat(num_samples, 1, 1)
 
-    if T >= model.config.max_seq_len:
+    cache_len = _cache_max_seq_len(model)
+
+    if T >= cache_len:
         raise ValueError(
-            f"Input sequence length {T} exceeds max_seq_len {model.config.max_seq_len}"
+            f"Input sequence length {T} exceeds cache_max_seq_len {cache_len}"
         )
 
     if max_new_tokens:
-        if T + max_new_tokens > model.config.max_seq_len:
-            max_new_tokens = model.config.max_seq_len - T
+        if T + max_new_tokens > cache_len:
+            max_new_tokens = cache_len - T
 
         T_new = T + max_new_tokens
     else:
-        T_new = model.config.max_seq_len
+        T_new = cache_len
         max_new_tokens = T_new - T
 
     device = prompt.device
@@ -283,7 +392,7 @@ def generate(
         with torch.device(device):
             model.setup_caches(
                 max_batch_size=1,  # Fixed to 1, avoid dynamic changes
-                max_seq_len=model.config.max_seq_len,
+                max_seq_len=cache_len,
                 dtype=next(model.parameters()).dtype,
             )
         model._cache_setup_done = True
@@ -293,7 +402,7 @@ def generate(
     # Create new tensor each time, but try to reuse memory
     input_pos = torch.arange(0, T, device=device, dtype=torch.long)
     empty = torch.empty(
-        (codebook_dim, model.config.max_seq_len), dtype=prompt.dtype, device=device
+        (codebook_dim, cache_len), dtype=prompt.dtype, device=device
     )
     empty[:, :T] = prompt
     seq = empty
@@ -321,9 +430,15 @@ def generate(
 
     prefill_decode = decode_one_token_ar
 
+    # Mark seq dim dynamic so one compiled graph works for any prompt length (1..cache_len).
+    x_prefill = prompt.view(1, codebook_dim, -1)
+    if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "mark_dynamic"):
+        torch._dynamo.mark_dynamic(x_prefill, 2, min=1, max=cache_len)
+        torch._dynamo.mark_dynamic(input_pos, 0, min=1, max=cache_len)
+
     first_token = prefill_decode(
         model,
-        prompt.view(1, codebook_dim, -1),
+        x_prefill,
         input_pos,
         temperature,
         top_p,
@@ -334,10 +449,11 @@ def generate(
     )
     seq[:, T : T + 1] = first_token
 
-    # Recreate input_pos
     input_pos = torch.tensor([T], device=device, dtype=torch.int)
+    stream_chunk_size = sampling_kwargs.pop("stream_chunk_size", None)
+    compile = sampling_kwargs.pop("compile", False)
 
-    x = decode_n_tokens(
+    decode_iter = decode_n_tokens(
         model,
         first_token.view(1, codebook_dim, -1),
         input_pos,
@@ -349,14 +465,24 @@ def generate(
         audio_masks=audio_masks,
         audio_parts=audio_parts,
         decode_one_token=decode_one_token,
+        stream_chunk_size=stream_chunk_size,
+        compile=compile,
     )
-    seq = seq[:, : T + 1 + x.size(1)]
-    seq[:, T + 1 :] = x
 
-    # Clean up temporary variables
-    del first_token, x, prompt, empty, input_pos
+    if stream_chunk_size is None:
+        # Non-streaming: single chunk from decode_n_tokens
+        x = next(iter(decode_iter))
+        seq = seq[:, : T + 1 + x.size(1)]
+        seq[:, T + 1 :] = x
+        del first_token, x, prompt, empty, input_pos
+        return seq
 
-    return seq
+    # Streaming: return a generator (no yield in this branch so generate() still returns when non-streaming)
+    def _stream():
+        yield first_token
+        yield from decode_iter
+
+    return _stream()
 
 
 def init_model(checkpoint_path, device, precision, compile=False):
@@ -382,11 +508,14 @@ def init_model(checkpoint_path, device, precision, compile=False):
 
     if compile:
         logger.info("Compiling function...")
+        # dynamic=True: one graph for variable prompt length (1..200+), avoid recompile on length change.
+        # If compile fails, try without dynamic=True; mark_dynamic() in generate() still helps.
         decode_one_token = torch.compile(
             decode_one_token,
             backend="inductor" if torch.cuda.is_available() else "aot_eager",
             mode="default" if torch.cuda.is_available() else None,
             fullgraph=True,
+            dynamic=True,
         )
 
     return model.eval(), decode_one_token
@@ -482,6 +611,29 @@ def split_text_by_speaker(text: str) -> list[str]:
     return turns
 
 
+def split_text_by_bytes(text: str, max_bytes: int) -> list[str]:
+    """
+    Split text into chunks of at most max_bytes (UTF-8). Used when there are
+    no speaker turns so that chunk_length still controls batch size for streaming.
+    """
+    if max_bytes <= 0 or len(text.encode("utf-8")) <= max_bytes:
+        return [text] if text.strip() else []
+    chunks = []
+    remaining = text
+    while remaining:
+        encoded = remaining.encode("utf-8")
+        if len(encoded) <= max_bytes:
+            chunks.append(remaining)
+            break
+        # Cut at max_bytes; avoid splitting multi-byte UTF-8 codepoints
+        cut = max_bytes
+        while cut > 0 and (encoded[cut] & 0xC0) == 0x80:
+            cut -= 1
+        chunks.append(encoded[:cut].decode("utf-8", errors="replace"))
+        remaining = encoded[cut:].decode("utf-8", errors="replace")
+    return chunks
+
+
 def group_turns_into_batches(
     turns: list[str], max_speakers: int = 3, max_bytes: int = 300
 ) -> list[str]:
@@ -537,6 +689,8 @@ def generate_long(
     chunk_length: int = 512,
     prompt_text: Optional[Union[str, list[str]]] = None,
     prompt_tokens: Optional[Union[torch.Tensor, list[torch.Tensor]]] = None,
+    stream_tokens: bool = False,
+    stream_chunk_size: int = 20,
 ):
     assert 0 < top_p <= 1, "top_p must be in (0, 1]"
     assert 0 < temperature < 2, "temperature must be in (0, 2)"
@@ -547,16 +701,16 @@ def generate_long(
         prompt_tokens = [prompt_tokens]
 
     if use_prompt:
-        assert len(prompt_text) == len(
-            prompt_tokens
-        ), "Prompt text and tokens must have the same length"
+        assert len(prompt_text) == len(prompt_tokens), (
+            "Prompt text and tokens must have the same length"
+        )
 
     if prompt_tokens:
         prompt_tokens = [i.cpu() for i in prompt_tokens]
 
     model_size = sum(p.numel() for p in model.parameters() if p.requires_grad)
     tokenizer = model.tokenizer
-    max_length = model.config.max_seq_len
+    max_length = _cache_max_seq_len(model)
 
     # Build base conversation with system message
     base_conversation = Conversation()
@@ -597,14 +751,18 @@ def generate_long(
         )
     )
 
-    # Split text by speaker and group into batches
+    # When stream_tokens=True: single batch (full text), yield token chunks from decode for low TTFA.
+    # Otherwise: split by speaker/chunk_length and run full generate() per batch.
     turns = split_text_by_speaker(text)
-    if turns:
+    if stream_tokens:
+        batches = [text]
+        logger.info("Token streaming: single batch (no text split)")
+    elif turns:
         batches = group_turns_into_batches(
             turns, max_speakers=5, max_bytes=chunk_length
         )
     else:
-        batches = [text]
+        batches = split_text_by_bytes(text, chunk_length)
 
     logger.info(f"Split into {len(turns)} turns, grouped into {len(batches)} batches")
 
@@ -667,63 +825,151 @@ def generate_long(
                     f"Audio masks non-zero count: {torch.count_nonzero(audio_masks)}"
                 )
 
-            if encoded.size(1) > max_length - 2048:
+            # Prompt + generation must fit in cache (max_length = cache_max_seq_len).
+            prompt_len = encoded.size(1)
+            if prompt_len > max_length:
                 raise ValueError(
-                    f"Prompt is too long: {encoded.size(1)} > {max_length - 2048}"
+                    f"Prompt length {prompt_len} exceeds KV cache size {max_length}. "
+                    f"Increase FISH_CACHE_MAX_SEQ_LEN (e.g. 1024 or 2048) or use a shorter reference."
                 )
+            if prompt_len + max_new_tokens > max_length:
+                max_new_tokens = max_length - prompt_len
+                logger.info(
+                    "Capping max_new_tokens to {} so prompt+gen fits in cache (prompt={}, cache={})",
+                    max_new_tokens,
+                    prompt_len,
+                    max_length,
+                )
+            # Optional hard cap for 32 GB VRAM: limit generation length to avoid OOM (e.g. FISH_MAX_NEW_TOKENS_CAP=80 with cache=384).
+            cap_env = os.environ.get("FISH_MAX_NEW_TOKENS_CAP", "").strip()
+            if cap_env:
+                try:
+                    cap = int(cap_env)
+                    if cap >= 1 and max_new_tokens > cap:
+                        max_new_tokens = cap
+                        logger.info(
+                            "Capping max_new_tokens to {} (FISH_MAX_NEW_TOKENS_CAP) for VRAM safety",
+                            max_new_tokens,
+                        )
+                except ValueError:
+                    pass
 
             encoded = encoded.to(device=device)
             prompt_length = encoded.size(1)
 
-            y = generate(
-                model=model,
-                prompt=encoded,
-                max_new_tokens=max_new_tokens,
-                audio_masks=audio_masks,
-                audio_parts=audio_parts,
-                decode_one_token=decode_one_token,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-            )
-
-            if sample_idx == 0 and batch_idx == 0 and compile:
-                logger.info(f"Compilation time: {time.perf_counter() - t0:.2f} seconds")
-
-            if torch.cuda.is_available():
-                torch.cuda.synchronize()
-
-            t_batch = time.perf_counter() - t0
-            tokens_generated = y.size(1) - prompt_length
-            tokens_sec = tokens_generated / t_batch if t_batch > 0 else 0
-            logger.info(
-                f"Batch {batch_idx}: Generated {tokens_generated} tokens in "
-                f"{t_batch:.02f} seconds, {tokens_sec:.02f} tokens/sec"
-            )
-            logger.info(
-                f"Bandwidth achieved: {model_size * tokens_sec / 1e9:.02f} GB/s"
-            )
-
-            # Extract generated codes
-            codes = y[1:, prompt_length:-1].clone()
-            assert (codes >= 0).all(), f"Negative code found: {codes}"
-
-            # Add assistant message with generated codes back to conversation
-            conversation.append(
-                Message(
-                    role="assistant",
-                    parts=[VQPart(codes=codes.cpu(), cal_loss=False)],
-                    cal_loss=False,
-                    modality="voice",
-                    add_im_start=True,
-                    add_im_end=True,
+            if stream_tokens:
+                # Token-level streaming: yield chunks as they're generated for low TTFA
+                logger.info(
+                    "stream: generate_long starting token stream batch_idx={} stream_chunk_size={}",
+                    batch_idx,
+                    stream_chunk_size,
                 )
-            )
+                gen = generate(
+                    model=model,
+                    prompt=encoded,
+                    max_new_tokens=max_new_tokens,
+                    audio_masks=audio_masks,
+                    audio_parts=audio_parts,
+                    decode_one_token=decode_one_token,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    stream_chunk_size=stream_chunk_size,
+                    compile=compile,
+                )
+                codes_list: list[torch.Tensor] = []
+                chunk_idx = 0
+                for chunk in gen:
+                    # chunk shape [11, K]; decoder expects codes as in current path (rows 1:)
+                    codes_chunk = chunk[1:, :].clone()
+                    if chunk_idx < 3:
+                        logger.info(
+                            "stream: generate_long chunk_idx={} chunk.shape={} codes_chunk.shape={}",
+                            chunk_idx,
+                            chunk.shape,
+                            codes_chunk.shape,
+                        )
+                    if (codes_chunk >= 0).all():
+                        yield GenerateResponse(
+                            action="sample", codes=codes_chunk, text=batch_text
+                        )
+                    codes_list.append(chunk)
+                    chunk_idx += 1
+                logger.info("stream: generate_long finished chunk_idx={} total_chunks={}", chunk_idx, len(codes_list))
+                codes = (
+                    torch.cat(codes_list, dim=1)[1:, :].clone()
+                    if codes_list
+                    else None
+                )
+                if codes is not None:
+                    conversation.append(
+                        Message(
+                            role="assistant",
+                            parts=[VQPart(codes=codes.cpu(), cal_loss=False)],
+                            cal_loss=False,
+                            modality="voice",
+                            add_im_start=True,
+                            add_im_end=True,
+                        )
+                    )
+                codes_list.clear()
+                del codes_list
+                if codes is not None:
+                    del codes
+                if sample_idx == 0 and batch_idx == 0 and compile:
+                    logger.info(
+                        f"Compilation time: {time.perf_counter() - t0:.2f} seconds"
+                    )
+                del encoded
+            else:
+                y = generate(
+                    model=model,
+                    prompt=encoded,
+                    max_new_tokens=max_new_tokens,
+                    audio_masks=audio_masks,
+                    audio_parts=audio_parts,
+                    decode_one_token=decode_one_token,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    compile=compile,
+                )
 
-            yield GenerateResponse(action="sample", codes=codes, text=batch_text)
+                if sample_idx == 0 and batch_idx == 0 and compile:
+                    logger.info(
+                        f"Compilation time: {time.perf_counter() - t0:.2f} seconds"
+                    )
 
-            # Cleanup
-            del y, encoded
+                if torch.cuda.is_available():
+                    torch.cuda.synchronize()
+
+                t_batch = time.perf_counter() - t0
+                tokens_generated = y.size(1) - prompt_length
+                tokens_sec = tokens_generated / t_batch if t_batch > 0 else 0
+                logger.info(
+                    f"Batch {batch_idx}: Generated {tokens_generated} tokens in "
+                    f"{t_batch:.02f} seconds, {tokens_sec:.02f} tokens/sec"
+                )
+                logger.info(
+                    f"Bandwidth achieved: {model_size * tokens_sec / 1e9:.02f} GB/s"
+                )
+
+                codes = y[1:, prompt_length:-1].clone()
+                assert (codes >= 0).all(), f"Negative code found: {codes}"
+
+                conversation.append(
+                    Message(
+                        role="assistant",
+                        parts=[VQPart(codes=codes.cpu(), cal_loss=False)],
+                        cal_loss=False,
+                        modality="voice",
+                        add_im_start=True,
+                        add_im_end=True,
+                    )
+                )
+
+                yield GenerateResponse(action="sample", codes=codes, text=batch_text)
+                del y, encoded
 
         if torch.cuda.is_available():
             logger.info(
@@ -745,25 +991,53 @@ class GenerateRequest:
     response_queue: queue.Queue
 
 
+def _model_param_memory_gb(module: torch.nn.Module) -> tuple[float, int]:
+    """Return (param_memory_gb, param_count) for a module (weights only)."""
+    total = 0
+    count = 0
+    for p in module.parameters():
+        total += p.numel() * p.element_size()
+        count += p.numel()
+    return (round(total / (1024**3), 3), count)
+
+
 def launch_thread_safe_queue(
     checkpoint_path,
     device,
     precision,
     compile: bool = False,
+    memory_info: dict | None = None,
 ):
+    """
+    memory_info: optional shared dict; worker will set llama_param_gb, llama_param_count after load.
+    """
     input_queue = queue.Queue()
     init_event = threading.Event()
 
     def worker():
+        profile_cadence = os.getenv("FISH_PROFILE_INFERENCE", "0") in {
+            "1",
+            "true",
+            "TRUE",
+            "yes",
+            "YES",
+        }
+
         model, decode_one_token = init_model(
             checkpoint_path, device, precision, compile=compile
         )
+        cache_len = _cache_max_seq_len(model)
+        logger.info("KV cache max_seq_len={} (model max={})", cache_len, model.config.max_seq_len)
         with torch.device(device):
             model.setup_caches(
                 max_batch_size=1,
-                max_seq_len=model.config.max_seq_len,
+                max_seq_len=cache_len,
                 dtype=next(model.parameters()).dtype,
             )
+        if memory_info is not None:
+            gb, count = _model_param_memory_gb(model)
+            memory_info["llama_param_gb"] = gb
+            memory_info["llama_param_count"] = count
         init_event.set()
 
         while True:
@@ -772,21 +1046,99 @@ def launch_thread_safe_queue(
                 break
 
             kwargs = item.request
+            req_tag = str(kwargs.pop("req_tag", "na"))
+            ack_queue = kwargs.pop("ack_queue", None)  # back-pressure: wait for main to finish DAC before next LLM chunk
             response_queue = item.response_queue
+            t_req_start = time.perf_counter()
+            t_last_put = t_req_start
+            stream_tokens = kwargs.get("stream_tokens", False)
+            put_count = 0
+            if stream_tokens:
+                logger.info("stream: worker got request req={} stream_chunk_size={}", req_tag, kwargs.get("stream_chunk_size"))
 
             try:
                 for chunk in generate_long(
                     model=model, decode_one_token=decode_one_token, **kwargs
                 ):
+                    if stream_tokens and put_count < 5:
+                        logger.info(
+                            "stream: worker putting chunk put_count={} action={} req={}",
+                            put_count,
+                            getattr(chunk, "action", None),
+                            req_tag,
+                        )
+                    put_count += 1
+                    if profile_cadence:
+                        now = time.perf_counter()
+                        delta_ms = (now - t_last_put) * 1000.0
+                        total_ms = (now - t_req_start) * 1000.0
+                        t_last_put = now
+                        action = getattr(chunk, "action", type(chunk).__name__)
+                        vram_s = ""
+                        if torch.cuda.is_available():
+                            vram_s = " vram_alloc_gb={:.2f} vram_max_gb={:.2f}".format(
+                                torch.cuda.memory_allocated() / (1024**3),
+                                torch.cuda.max_memory_allocated() / (1024**3),
+                            )
+                        logger.info(
+                            "queue_put req={} action={} delta_ms={:.1f} total_ms={:.1f}{}",
+                            req_tag,
+                            action,
+                            delta_ms,
+                            total_ms,
+                            vram_s,
+                        )
+                    # Send chunk with codes on CPU so queue/main never hold GPU tensors; avoids 24 GB stuck after request on 32 GB.
+                    out = chunk
+                    codes = getattr(chunk, "codes", None)
+                    if codes is not None and codes.is_cuda:
+                        out = GenerateResponse(
+                            action=chunk.action,
+                            codes=codes.cpu(),
+                            text=getattr(chunk, "text", None),
+                        )
                     response_queue.put(
-                        WrappedGenerateResponse(status="success", response=chunk)
+                        WrappedGenerateResponse(status="success", response=out)
                     )
+                    # Back-pressure: wait for main thread to finish DAC decode so we don't run LLM and DAC on GPU at once (OOM on 32 GB).
+                    if stream_tokens and ack_queue is not None:
+                        ack_queue.get()
+                    # During streaming, free cache after each chunk to reduce fragmentation (32 GB often OOMs by mid-stream)
+                    if stream_tokens and torch.cuda.is_available():
+                        torch.cuda.empty_cache()
 
-                # Only clear cache after complete request batch
+                # Release KV cache and clear allocator so next request starts near baseline (avoids OOM on 32 GB).
+                logger.info("worker: post-request cleanup starting")
                 if torch.cuda.is_available():
+                    before_clear_gb = round(torch.cuda.memory_allocated() / (1024**3), 2)
+                clear_caches_fn = getattr(model, "clear_caches", None)
+                if clear_caches_fn is not None:
+                    try:
+                        clear_caches_fn()
+                        if torch.cuda.is_available():
+                            after_clear_gb = round(torch.cuda.memory_allocated() / (1024**3), 2)
+                            logger.info(
+                                "worker: clear_caches done alloc before={} GB after={} GB",
+                                before_clear_gb,
+                                after_clear_gb,
+                            )
+                    except Exception as clear_err:
+                        logger.warning("clear_caches failed: %s", clear_err)
+                if torch.cuda.is_available():
+                    gc.collect()
+                    torch.cuda.synchronize()
+                    torch.cuda.empty_cache()
+                    gc.collect()
                     torch.cuda.empty_cache()
 
             except Exception as e:
+                logger.error(
+                    "stream: worker EXCEPTION req={} put_count={}: {}",
+                    req_tag,
+                    put_count,
+                    e,
+                    exc_info=True,
+                )
                 logger.error(traceback.format_exc())
                 response_queue.put(WrappedGenerateResponse(status="error", response=e))
                 # Clear cache on error
@@ -880,7 +1232,7 @@ def main(
     with torch.device(device):
         model.setup_caches(
             max_batch_size=1,
-            max_seq_len=model.config.max_seq_len,
+            max_seq_len=_cache_max_seq_len(model),
             dtype=next(model.parameters()).dtype,
         )
     if torch.cuda.is_available():

--- a/fish_speech/models/text2semantic/llama.py
+++ b/fish_speech/models/text2semantic/llama.py
@@ -323,6 +323,16 @@ class BaseTransformer(nn.Module):
                 dtype=dtype,
             )
 
+    def clear_caches(self) -> None:
+        """Release KV cache buffers so VRAM can be freed between requests (avoids OOM on 32 GB)."""
+        if not getattr(self, "_cache_setup_done", False):
+            return
+        for b in self.layers:
+            b.attention.kv_cache = None
+        self._cache_setup_done = False
+        self.max_seq_len = -1
+        self.max_batch_size = -1
+
     def embed(self, inp: Tensor) -> Tensor:
         embeds = []
 
@@ -719,6 +729,11 @@ class DualARTransformer(BaseTransformer):
                 self.config.fast_head_dim,
                 dtype=dtype,
             )
+
+    def clear_caches(self) -> None:
+        super().clear_caches()
+        for b in self.fast_layers:
+            b.attention.kv_cache = None
 
     def forward(
         self,

--- a/fish_speech/utils/schema.py
+++ b/fish_speech/utils/schema.py
@@ -95,7 +95,10 @@ class ServeTTSRequest(BaseModel):
     normalize: bool = True
     # not usually used below
     streaming: bool = False
-    max_new_tokens: int = 1024
+    # When True, stream token chunks (low TTFA) instead of splitting text into batches
+    stream_tokens: bool = False
+    stream_chunk_size: Annotated[int, conint(ge=1, le=200, strict=True)] = 20
+    max_new_tokens: int = 512
     top_p: Annotated[float, Field(ge=0.1, le=1.0, strict=True)] = 0.8
     repetition_penalty: Annotated[float, Field(ge=0.9, le=2.0, strict=True)] = 1.1
     temperature: Annotated[float, Field(ge=0.1, le=1.0, strict=True)] = 0.8
@@ -113,6 +116,13 @@ class AddReferenceRequest(BaseModel):
 
 class AddReferenceResponse(BaseModel):
     success: bool
+    message: str
+    reference_id: str
+
+
+class AddEncodedReferenceResponse(BaseModel):
+    success: bool
+    status: str  # "created" | "updated" | "unchanged"
     message: str
     reference_id: str
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ cu129 = [
   "torch==2.8.0",
   "torchaudio",
 ]
+dev = [
+  "pytest>=7.0.0",
+]
 
 [tool.uv]
 conflicts = [
@@ -119,6 +122,11 @@ explicit = true
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]
 
 [tool.setuptools]
 packages = ["fish_speech", "tools"]

--- a/scripts/e2e_memory.sh
+++ b/scripts/e2e_memory.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# E2E memory check: two TTS requests to verify VRAM is freed between requests (no OOM on 32GB).
+# Server must be running. Usage: PORT=8080 ./scripts/e2e_memory.sh   or: make e2e-memory
+set -e
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+PORT="${PORT:-8080}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:${PORT}}"
+HEALTH_TIMEOUT="${E2E_HEALTH_TIMEOUT:-120}"
+OUT_DIR="${E2E_OUT_DIR:-$REPO_ROOT/results/e2e}"
+mkdir -p "$OUT_DIR"
+
+echo "=== Fish Speech E2E memory (2 requests) ==="
+echo "  BASE_URL=$BASE_URL"
+echo ""
+
+echo "Waiting for server (timeout ${HEALTH_TIMEOUT}s)..."
+WAIT=0
+until curl -sf --connect-timeout 2 "$BASE_URL/v1/health" >/dev/null 2>&1; do
+  sleep 2
+  WAIT=$((WAIT + 2))
+  if [[ $WAIT -ge $HEALTH_TIMEOUT ]]; then
+    echo "ERROR: server not ready"
+    exit 1
+  fi
+done
+echo "Server ready."
+echo ""
+
+MEM1="$OUT_DIR/memory_before.json"
+MEM2="$OUT_DIR/memory_after_req1.json"
+MEM3="$OUT_DIR/memory_after_req2.json"
+
+echo "Memory before:"
+curl -sf "$BASE_URL/v1/debug/memory" | tee "$MEM1" | (command -v jq >/dev/null 2>&1 && jq -c '{allocated_gb, reserved_gb}' || cat)
+echo ""
+
+echo "Request 1 (streaming)..."
+curl -sf -X POST "$BASE_URL/v1/tts" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hello, this is the first request.","streaming":true}' \
+  --output "$OUT_DIR/e2e_mem_req1.wav" --max-time 60
+echo "Memory after request 1:"
+curl -sf "$BASE_URL/v1/debug/memory" | tee "$MEM2" | (command -v jq >/dev/null 2>&1 && jq -c '{allocated_gb, reserved_gb, max_allocated_gb}' || cat)
+echo ""
+
+sleep 2
+echo "Request 2 (streaming, OOM check)..."
+if curl -sf -X POST "$BASE_URL/v1/tts" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Second request to confirm memory is freed.","streaming":true}' \
+  --output "$OUT_DIR/e2e_mem_req2.wav" --max-time 60; then
+  echo "Request 2: OK"
+else
+  echo "Request 2: FAIL (possible OOM)"
+  exit 1
+fi
+echo "Memory after request 2:"
+curl -sf "$BASE_URL/v1/debug/memory" | tee "$MEM3" | (command -v jq >/dev/null 2>&1 && jq -c '{allocated_gb, reserved_gb, max_allocated_gb}' || cat)
+echo ""
+
+echo "E2E memory passed (two requests succeeded). Outputs in $OUT_DIR"

--- a/scripts/e2e_smoke.sh
+++ b/scripts/e2e_smoke.sh
@@ -32,25 +32,37 @@ echo ""
 # Optional: use first reference from server (e.g. after preencode + upload)
 REF_ID=""
 if command -v jq >/dev/null 2>&1; then
-  REF_ID=$(curl -sf "$BASE_URL/v1/references/list" | jq -r '.reference_ids[0] // empty')
+  REF_ID=$(curl -sf --compressed "$BASE_URL/v1/references/list" 2>/dev/null | jq -r '.reference_ids[0] // empty' 2>/dev/null) || true
 fi
 if [[ -n "$REF_ID" ]]; then
   echo "Using reference_id=$REF_ID for TTS"
 fi
 echo ""
 
-# Streaming TTS
+# Streaming TTS (with TTFA metrics when python3 + ttfa_smoke.py available)
 echo "--- TTS streaming ---"
 STREAM_OUT="$OUT_DIR/e2e_stream.wav"
-if [[ -n "$REF_ID" ]]; then
-  TTS_JSON="{\"text\":\"Hello, this is an e2e smoke test.\",\"streaming\":true,\"reference_id\":\"$REF_ID\"}"
-else
-  TTS_JSON='{"text":"Hello, this is an e2e smoke test.","streaming":true}'
+TTFA_OK=0
+if command -v python3 >/dev/null 2>&1 && [[ -f "$REPO_ROOT/scripts/ttfa_smoke.py" ]]; then
+  TTFA_ARGS="--url $BASE_URL --output $STREAM_OUT"
+  [[ -n "$REF_ID" ]] && TTFA_ARGS="$TTFA_ARGS --reference-id $REF_ID"
+  if python3 "$REPO_ROOT/scripts/ttfa_smoke.py" $TTFA_ARGS && [[ -s "$STREAM_OUT" ]]; then
+    TTFA_OK=1
+  else
+    echo "  (ttfa_smoke failed, falling back to curl)"
+  fi
 fi
-curl -sf -X POST "$BASE_URL/v1/tts" \
-  -H "Content-Type: application/json" \
-  -d "$TTS_JSON" \
-  --output "$STREAM_OUT" --max-time 60
+if [[ "$TTFA_OK" -ne 1 ]]; then
+  if [[ -n "$REF_ID" ]]; then
+    TTS_JSON="{\"text\":\"Hello, this is an e2e smoke test.\",\"streaming\":true,\"reference_id\":\"$REF_ID\"}"
+  else
+    TTS_JSON='{"text":"Hello, this is an e2e smoke test.","streaming":true}'
+  fi
+  curl -sf -X POST "$BASE_URL/v1/tts" \
+    -H "Content-Type: application/json" \
+    -d "$TTS_JSON" \
+    --output "$STREAM_OUT" --max-time 60
+fi
 if [[ ! -s "$STREAM_OUT" ]]; then
   echo "ERROR: streaming TTS produced empty or missing file: $STREAM_OUT"
   exit 1
@@ -58,18 +70,30 @@ fi
 echo "  OK: $STREAM_OUT ($(wc -c < "$STREAM_OUT") bytes)"
 echo ""
 
-# Oneshot TTS
+# Oneshot TTS (with timing metrics when python3 + ttfa_smoke.py available)
 echo "--- TTS oneshot ---"
 ONESHOT_OUT="$OUT_DIR/e2e_oneshot.wav"
-if [[ -n "$REF_ID" ]]; then
-  ONESHOT_JSON="{\"text\":\"Short test.\",\"streaming\":false,\"reference_id\":\"$REF_ID\"}"
-else
-  ONESHOT_JSON='{"text":"Short test.","streaming":false}'
+ONESHOT_TTFA_OK=0
+if command -v python3 >/dev/null 2>&1 && [[ -f "$REPO_ROOT/scripts/ttfa_smoke.py" ]]; then
+  ONESHOT_ARGS="--url $BASE_URL --output $ONESHOT_OUT --oneshot"
+  [[ -n "$REF_ID" ]] && ONESHOT_ARGS="$ONESHOT_ARGS --reference-id $REF_ID"
+  if python3 "$REPO_ROOT/scripts/ttfa_smoke.py" $ONESHOT_ARGS && [[ -s "$ONESHOT_OUT" ]]; then
+    ONESHOT_TTFA_OK=1
+  else
+    echo "  (ttfa_smoke oneshot failed, falling back to curl)"
+  fi
 fi
-curl -sf -X POST "$BASE_URL/v1/tts" \
-  -H "Content-Type: application/json" \
-  -d "$ONESHOT_JSON" \
-  --output "$ONESHOT_OUT" --max-time 60
+if [[ "$ONESHOT_TTFA_OK" -ne 1 ]]; then
+  if [[ -n "$REF_ID" ]]; then
+    ONESHOT_JSON="{\"text\":\"Short test.\",\"streaming\":false,\"reference_id\":\"$REF_ID\"}"
+  else
+    ONESHOT_JSON='{"text":"Short test.","streaming":false}'
+  fi
+  curl -sf -X POST "$BASE_URL/v1/tts" \
+    -H "Content-Type: application/json" \
+    -d "$ONESHOT_JSON" \
+    --output "$ONESHOT_OUT" --max-time 60
+fi
 if [[ ! -s "$ONESHOT_OUT" ]]; then
   echo "ERROR: oneshot TTS produced empty or missing file: $ONESHOT_OUT"
   exit 1
@@ -79,7 +103,7 @@ echo ""
 
 # Memory
 echo "--- Memory ---"
-curl -sf "$BASE_URL/v1/debug/memory" | tee "$OUT_DIR/memory_after.json" | (command -v jq >/dev/null 2>&1 && jq -c '{allocated_gb, reserved_gb, max_allocated_gb}' || cat)
+curl -sf --compressed "$BASE_URL/v1/debug/memory" | tee "$OUT_DIR/memory_after.json" | (command -v jq >/dev/null 2>&1 && jq -c '{allocated_gb, reserved_gb, max_allocated_gb}' 2>/dev/null || cat) || true
 echo ""
 
 echo "E2E smoke passed. Outputs in $OUT_DIR"

--- a/scripts/e2e_smoke.sh
+++ b/scripts/e2e_smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# E2E smoke: server must be running (e.g. ./scripts/run_server_32gb.sh).
+# Waits for health, runs TTS (streaming + oneshot), checks /v1/debug/memory.
+# Usage: PORT=8080 ./scripts/e2e_smoke.sh   or: make e2e
+set -e
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+PORT="${PORT:-8080}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:${PORT}}"
+CONTAINER="${CONTAINER:-fish-speech}"
+HEALTH_TIMEOUT="${E2E_HEALTH_TIMEOUT:-120}"
+OUT_DIR="${E2E_OUT_DIR:-$REPO_ROOT/results/e2e}"
+mkdir -p "$OUT_DIR"
+
+echo "=== Fish Speech E2E smoke ==="
+echo "  BASE_URL=$BASE_URL  CONTAINER=$CONTAINER  OUT_DIR=$OUT_DIR"
+echo ""
+
+echo "Waiting for server (timeout ${HEALTH_TIMEOUT}s)..."
+WAIT=0
+until curl -sf --connect-timeout 2 "$BASE_URL/v1/health" >/dev/null 2>&1; do
+  sleep 2
+  WAIT=$((WAIT + 2))
+  if [[ $WAIT -ge $HEALTH_TIMEOUT ]]; then
+    echo "ERROR: server not ready in ${HEALTH_TIMEOUT}s"
+    exit 1
+  fi
+done
+echo "Server ready after ${WAIT}s."
+echo ""
+
+# Optional: use first reference from server (e.g. after preencode + upload)
+REF_ID=""
+if command -v jq >/dev/null 2>&1; then
+  REF_ID=$(curl -sf "$BASE_URL/v1/references/list" | jq -r '.reference_ids[0] // empty')
+fi
+if [[ -n "$REF_ID" ]]; then
+  echo "Using reference_id=$REF_ID for TTS"
+fi
+echo ""
+
+# Streaming TTS
+echo "--- TTS streaming ---"
+STREAM_OUT="$OUT_DIR/e2e_stream.wav"
+if [[ -n "$REF_ID" ]]; then
+  TTS_JSON="{\"text\":\"Hello, this is an e2e smoke test.\",\"streaming\":true,\"reference_id\":\"$REF_ID\"}"
+else
+  TTS_JSON='{"text":"Hello, this is an e2e smoke test.","streaming":true}'
+fi
+curl -sf -X POST "$BASE_URL/v1/tts" \
+  -H "Content-Type: application/json" \
+  -d "$TTS_JSON" \
+  --output "$STREAM_OUT" --max-time 60
+if [[ ! -s "$STREAM_OUT" ]]; then
+  echo "ERROR: streaming TTS produced empty or missing file: $STREAM_OUT"
+  exit 1
+fi
+echo "  OK: $STREAM_OUT ($(wc -c < "$STREAM_OUT") bytes)"
+echo ""
+
+# Oneshot TTS
+echo "--- TTS oneshot ---"
+ONESHOT_OUT="$OUT_DIR/e2e_oneshot.wav"
+if [[ -n "$REF_ID" ]]; then
+  ONESHOT_JSON="{\"text\":\"Short test.\",\"streaming\":false,\"reference_id\":\"$REF_ID\"}"
+else
+  ONESHOT_JSON='{"text":"Short test.","streaming":false}'
+fi
+curl -sf -X POST "$BASE_URL/v1/tts" \
+  -H "Content-Type: application/json" \
+  -d "$ONESHOT_JSON" \
+  --output "$ONESHOT_OUT" --max-time 60
+if [[ ! -s "$ONESHOT_OUT" ]]; then
+  echo "ERROR: oneshot TTS produced empty or missing file: $ONESHOT_OUT"
+  exit 1
+fi
+echo "  OK: $ONESHOT_OUT ($(wc -c < "$ONESHOT_OUT") bytes)"
+echo ""
+
+# Memory
+echo "--- Memory ---"
+curl -sf "$BASE_URL/v1/debug/memory" | tee "$OUT_DIR/memory_after.json" | (command -v jq >/dev/null 2>&1 && jq -c '{allocated_gb, reserved_gb, max_allocated_gb}' || cat)
+echo ""
+
+echo "E2E smoke passed. Outputs in $OUT_DIR"

--- a/scripts/preencode.sh
+++ b/scripts/preencode.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Pre-encode reference WAV+txt to references/. Optional: upload to server.
+# Env: PREENCODE_INPUT_DIR, PREENCODE_OUTPUT_DIR, PREENCODE_CHECKPOINT, PREENCODE_REF_ID, UPLOAD, SERVER_URL
+# Usage: ./scripts/preencode.sh   or   UPLOAD=1 ./scripts/preencode.sh
+set -e
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+INPUT_DIR="${PREENCODE_INPUT_DIR:-data/voice_references}"
+OUTPUT_DIR="${PREENCODE_OUTPUT_DIR:-references}"
+CHECKPOINT="${PREENCODE_CHECKPOINT:-checkpoints/s2-pro/codec.pth}"
+REF_ID="${PREENCODE_REF_ID:-}"
+UPLOAD="${UPLOAD:-0}"
+SERVER_URL="${SERVER_URL:-http://127.0.0.1:8080}"
+
+if [[ ! -d "$INPUT_DIR" ]]; then
+  echo "ERROR: PREENCODE_INPUT_DIR=$INPUT_DIR not found. Create folder with <stem>.wav + <stem>.txt"
+  exit 1
+fi
+if [[ ! -f "$CHECKPOINT" ]]; then
+  echo "ERROR: PREENCODE_CHECKPOINT=$CHECKPOINT not found. E.g. PREENCODE_CHECKPOINT=../../checkpoints/s2-pro/codec.pth"
+  exit 1
+fi
+
+set -- --input-dir "$INPUT_DIR" --output-dir "$OUTPUT_DIR" --checkpoint-path "$CHECKPOINT"
+[[ -n "$REF_ID" ]] && set -- "$@" --ref-id "$REF_ID"
+[[ "$UPLOAD" =~ ^(1|true|yes|YES)$ ]] && set -- "$@" --upload --server-url "$SERVER_URL"
+
+exec uv run python tools/preencode_references.py "$@"

--- a/scripts/run_server_32gb.sh
+++ b/scripts/run_server_32gb.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Minimal repro: run API server in Docker for 32GB VRAM (e.g. RTX 5090).
+# From repo root: ./scripts/run_server_32gb.sh
+# Optional: COMPILE=1; PORT=8080; CONTAINER=fish-speech
+# If fish-speech is in a parent repo (e.g. .cache/fish-speech): WORKSPACE_DIR=/path/to/parent CHECKPOINTS_DIR=checkpoints/s2-pro
+set -e
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+IMAGE="${IMAGE:-fish-speech-webui:cu129}"
+CONTAINER="${CONTAINER:-fish-speech}"
+PORT="${PORT:-8080}"
+COMPILE="${COMPILE:-0}"
+CHECKPOINTS_DIR="${CHECKPOINTS_DIR:-checkpoints/s2-pro}"
+
+# When running from a parent repo: mount parent as /workspace so checkpoints and repo are both visible
+if [[ -n "$WORKSPACE_DIR" ]]; then
+  WORKSPACE_DIR="$(cd "$WORKSPACE_DIR" && pwd)"
+  REPO_REL="$(python3 -c "import os; print(os.path.relpath('$REPO_ROOT', '$WORKSPACE_DIR'))")"
+  MOUNT_ROOT="$WORKSPACE_DIR"
+  CHECKPOINTS_REL="$CHECKPOINTS_DIR"
+else
+  MOUNT_ROOT="$REPO_ROOT"
+  REPO_REL="."
+  CHECKPOINTS_REL="$CHECKPOINTS_DIR"
+fi
+
+echo "=== Fish Speech API (32GB / RTX 5090 style) ==="
+echo "  MOUNT_ROOT=$MOUNT_ROOT  REPO_REL=$REPO_REL  CHECKPOINTS=$CHECKPOINTS_REL"
+echo "  IMAGE=$IMAGE  CONTAINER=$CONTAINER  PORT=$PORT  COMPILE=$COMPILE"
+echo ""
+
+# 1) Build image if not present (CUDA 12.9 for modern GPUs)
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "Building image $IMAGE (this may take a while)..."
+  docker build --platform linux/amd64 -f docker/Dockerfile \
+    --build-arg BACKEND=cuda \
+    --build-arg CUDA_VER=12.9.0 \
+    --build-arg UV_EXTRA=cu129 \
+    --target webui \
+    -t "$IMAGE" .
+  echo "Build done."
+else
+  echo "Using existing image $IMAGE"
+fi
+
+# 2) Download checkpoints if missing (only when checkpoints live under repo)
+if [[ -z "$WORKSPACE_DIR" ]]; then
+  if [[ ! -d "$REPO_ROOT/$CHECKPOINTS_DIR" ]] || [[ -z "$(ls -A "$REPO_ROOT/$CHECKPOINTS_DIR" 2>/dev/null)" ]]; then
+    echo "Downloading s2-pro checkpoints to $CHECKPOINTS_DIR ..."
+    mkdir -p "$REPO_ROOT/$CHECKPOINTS_DIR"
+    docker run --rm \
+      -v "$REPO_ROOT":/workspace -w /workspace \
+      "$IMAGE" \
+      /app/.venv/bin/huggingface-cli download fishaudio/s2-pro --local-dir "$CHECKPOINTS_DIR"
+    echo "Download done."
+  else
+    echo "Checkpoints found at $CHECKPOINTS_DIR"
+  fi
+else
+  if [[ ! -d "$WORKSPACE_DIR/$CHECKPOINTS_DIR" ]] || [[ -z "$(ls -A "$WORKSPACE_DIR/$CHECKPOINTS_DIR" 2>/dev/null)" ]]; then
+    echo "ERROR: WORKSPACE_DIR set but $WORKSPACE_DIR/$CHECKPOINTS_DIR not found. Create it or run without WORKSPACE_DIR to download into repo."
+    exit 1
+  fi
+  echo "Checkpoints found at $WORKSPACE_DIR/$CHECKPOINTS_DIR"
+fi
+
+# 3) Stop existing container if any
+docker rm -f "$CONTAINER" 2>/dev/null || true
+
+# 4) Run server (tuned for 32GB: cache=384, max_new_tokens cap=80; warmup when COMPILE=1)
+echo "Starting server on port $PORT ..."
+docker run -d --rm --name "$CONTAINER" \
+  -p "$PORT:8080" \
+  --gpus all \
+  -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+  -e FISH_CACHE_MAX_SEQ_LEN=384 \
+  -e FISH_MAX_NEW_TOKENS_CAP=80 \
+  -e PYTHONPATH=/workspace/"$REPO_REL" \
+  -v "$MOUNT_ROOT":/workspace -w /workspace \
+  --entrypoint /app/.venv/bin/python \
+  "$IMAGE" \
+  /workspace/"$REPO_REL"/tools/api_server.py \
+  --listen 0.0.0.0:8080 \
+  --device cuda \
+  --llama-checkpoint-path "/workspace/$CHECKPOINTS_REL" \
+  --decoder-checkpoint-path "/workspace/$CHECKPOINTS_REL/codec.pth" \
+  $([ "$COMPILE" = "1" ] && echo --compile || true)
+
+echo ""
+echo "Server starting. With COMPILE=1, warmup runs at startup (2–10 min); then /v1/health returns 200."
+echo "  Health:  curl -s http://127.0.0.1:$PORT/v1/health"
+echo "  TTS:    curl -X POST http://127.0.0.1:$PORT/v1/tts -H 'Content-Type: application/json' -d '{\"text\":\"Hello\",\"streaming\":true}' --output out.wav"
+echo "  Memory: curl -s http://127.0.0.1:$PORT/v1/debug/memory"
+echo "  Logs:   docker logs -f $CONTAINER"

--- a/scripts/run_server_32gb.sh
+++ b/scripts/run_server_32gb.sh
@@ -49,9 +49,10 @@ if [[ -z "$WORKSPACE_DIR" ]]; then
     echo "Downloading s2-pro checkpoints to $CHECKPOINTS_DIR ..."
     mkdir -p "$REPO_ROOT/$CHECKPOINTS_DIR"
     docker run --rm \
+      --entrypoint /app/.venv/bin/huggingface-cli \
       -v "$REPO_ROOT":/workspace -w /workspace \
       "$IMAGE" \
-      /app/.venv/bin/huggingface-cli download fishaudio/s2-pro --local-dir "$CHECKPOINTS_DIR"
+      download fishaudio/s2-pro --local-dir "$CHECKPOINTS_DIR"
     echo "Download done."
   else
     echo "Checkpoints found at $CHECKPOINTS_DIR"

--- a/scripts/ttfa_smoke.py
+++ b/scripts/ttfa_smoke.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""One TTS request (streaming or oneshot): measure TTFA and save WAV. Prints ttfa_s, ttfa_audio_s, total_s."""
+import argparse
+import sys
+import time
+
+WAV_HEADER_SIZE = 44
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="TTS request with TTFA/timing metrics")
+    p.add_argument("--url", required=True, help="Base URL (e.g. http://127.0.0.1:8080)")
+    p.add_argument("--output", required=True, help="Output WAV path")
+    p.add_argument("--reference-id", default=None, help="Optional reference_id")
+    p.add_argument("--text", default=None, help="Text to synthesize (default depends on --oneshot)")
+    p.add_argument("--oneshot", action="store_true", help="Non-streaming request (streaming: false)")
+    args = p.parse_args()
+    if args.text is None:
+        args.text = "Short test." if args.oneshot else "Hello, this is an e2e smoke test."
+
+    try:
+        import urllib.request
+    except ImportError:
+        print("ERROR: urllib.request required", file=sys.stderr)
+        sys.exit(1)
+
+    url = f"{args.url.rstrip('/')}/v1/tts"
+    body = {"text": args.text, "streaming": not args.oneshot}
+    if args.reference_id:
+        body["reference_id"] = args.reference_id
+    import json
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    t0 = time.perf_counter()
+    t1: float | None = None  # first byte
+    t2: float | None = None  # first audio byte (after 44-byte header)
+    out_bytes: list[bytes] = []
+    bytes_read = 0
+
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        while True:
+            chunk = resp.read(8192)
+            if not chunk:
+                break
+            if t1 is None:
+                t1 = time.perf_counter()
+            out_bytes.append(chunk)
+            bytes_read += len(chunk)
+            if t2 is None and bytes_read > WAV_HEADER_SIZE:
+                t2 = time.perf_counter()
+    t3 = time.perf_counter()
+
+    with open(args.output, "wb") as f:
+        f.write(b"".join(out_bytes))
+
+    ttfa_s = (t1 - t0) if t1 is not None else 0.0
+    ttfa_audio_s = (t2 - t0) if t2 is not None else ttfa_s
+    total_s = t3 - t0
+    print(f"  ttfa_s={ttfa_s:.3f}  ttfa_audio_s={ttfa_audio_s:.3f}  total_s={total_s:.3f}  bytes={bytes_read}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ttfa_smoke.py
+++ b/scripts/ttfa_smoke.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """One TTS request (streaming or oneshot): measure TTFA and save WAV. Prints ttfa_s, ttfa_audio_s, total_s."""
+
 import argparse
 import sys
 import time
@@ -12,11 +13,19 @@ def main() -> None:
     p.add_argument("--url", required=True, help="Base URL (e.g. http://127.0.0.1:8080)")
     p.add_argument("--output", required=True, help="Output WAV path")
     p.add_argument("--reference-id", default=None, help="Optional reference_id")
-    p.add_argument("--text", default=None, help="Text to synthesize (default depends on --oneshot)")
-    p.add_argument("--oneshot", action="store_true", help="Non-streaming request (streaming: false)")
+    p.add_argument(
+        "--text", default=None, help="Text to synthesize (default depends on --oneshot)"
+    )
+    p.add_argument(
+        "--oneshot",
+        action="store_true",
+        help="Non-streaming request (streaming: false)",
+    )
     args = p.parse_args()
     if args.text is None:
-        args.text = "Short test." if args.oneshot else "Hello, this is an e2e smoke test."
+        args.text = (
+            "Short test." if args.oneshot else "Hello, this is an e2e smoke test."
+        )
 
     try:
         import urllib.request
@@ -29,6 +38,7 @@ def main() -> None:
     if args.reference_id:
         body["reference_id"] = args.reference_id
     import json
+
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(
         url,
@@ -62,7 +72,9 @@ def main() -> None:
     ttfa_s = (t1 - t0) if t1 is not None else 0.0
     ttfa_audio_s = (t2 - t0) if t2 is not None else ttfa_s
     total_s = t3 - t0
-    print(f"  ttfa_s={ttfa_s:.3f}  ttfa_audio_s={ttfa_audio_s:.3f}  total_s={total_s:.3f}  bytes={bytes_read}")
+    print(
+        f"  ttfa_s={ttfa_s:.3f}  ttfa_audio_s={ttfa_audio_s:.3f}  total_s={total_s:.3f}  bytes={bytes_read}"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/upload_references.sh
+++ b/scripts/upload_references.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Upload existing references/ to server (no encoding). Server skips if hash matches.
+# Env: PREENCODE_OUTPUT_DIR, SERVER_URL (or BASE_URL)
+# Usage: ./scripts/upload_references.sh   or   make upload-references
+set -e
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUTPUT_DIR="${PREENCODE_OUTPUT_DIR:-references}"
+SERVER_URL="${SERVER_URL:-${BASE_URL:-http://127.0.0.1:8080}}"
+
+exec uv run python tools/preencode_references.py \
+  --output-dir "$OUTPUT_DIR" \
+  --upload-only --server-url "$SERVER_URL"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for fish-speech

--- a/tests/test_debug_memory_dump.py
+++ b/tests/test_debug_memory_dump.py
@@ -1,0 +1,54 @@
+"""
+Tests for /v1/debug/memory dump (CUDA memory snapshot).
+Run in env with torch + tools deps: pytest tests/test_debug_memory_dump.py -v
+"""
+import tempfile
+import unittest.mock as mock
+
+import pytest
+
+# Need full app deps (torch, ormsgpack, kui, …) to import views
+pytest.importorskip("torch")
+pytest.importorskip("ormsgpack")
+
+
+def test_dump_memory_snapshot_no_cuda():
+    """When CUDA is not available, _dump_memory_snapshot returns (None, error message)."""
+    from tools.server.views import _dump_memory_snapshot
+
+    with mock.patch("tools.server.views.torch") as mtorch:
+        mtorch.cuda.is_available.return_value = False
+        path, err = _dump_memory_snapshot(out_dir=tempfile.gettempdir())
+    assert path is None
+    assert err == "CUDA not available"
+
+
+def test_dump_memory_snapshot_no_dump_fn():
+    """When _dump_snapshot is missing, returns (None, error message)."""
+    import torch
+
+    from tools.server.views import _dump_memory_snapshot
+
+    with mock.patch("tools.server.views.torch") as mtorch:
+        mtorch.cuda.is_available.return_value = True
+        mtorch.cuda.memory._dump_snapshot = None
+        path, err = _dump_memory_snapshot(out_dir=tempfile.gettempdir())
+    assert path is None
+    assert "_dump_snapshot" in (err or "")
+
+
+def test_dump_memory_snapshot_dump_fails():
+    """When _dump_snapshot raises, returns (None, error message)."""
+    import torch
+
+    from tools.server.views import _dump_memory_snapshot
+
+    with mock.patch("tools.server.views.torch") as mtorch:
+        mtorch.cuda.is_available.return_value = True
+        mtorch.cuda.memory._dump_snapshot = mock.Mock(
+            side_effect=RuntimeError("_cuda_memorySnapshot not found")
+        )
+        path, err = _dump_memory_snapshot(out_dir=tempfile.gettempdir())
+    assert path is None
+    assert err is not None
+    assert "Dump failed" in err or "RuntimeError" in err

--- a/tests/test_debug_memory_dump.py
+++ b/tests/test_debug_memory_dump.py
@@ -2,6 +2,7 @@
 Tests for /v1/debug/memory dump (CUDA memory snapshot).
 Run in env with torch + tools deps: pytest tests/test_debug_memory_dump.py -v
 """
+
 import tempfile
 import unittest.mock as mock
 

--- a/tests/test_inference_engine.py
+++ b/tests/test_inference_engine.py
@@ -1,0 +1,47 @@
+"""
+Tests for inference_engine (get_audio_segment and related).
+Run: pytest tests/test_inference_engine.py -v
+"""
+import unittest.mock as mock
+
+import numpy as np
+import pytest
+import torch
+
+from fish_speech.inference_engine import TTSInferenceEngine
+from fish_speech.models.text2semantic.inference import GenerateResponse
+
+
+class TestGetAudioSegment:
+    """get_audio_segment must use .detach() before .numpy() when inference_mode is not used."""
+
+    def test_returns_numpy_when_decode_vq_returns_tensor_requiring_grad(self):
+        """
+        When decode_vq_tokens returns a tensor with requires_grad=True (e.g. without inference_mode),
+        get_audio_segment must still return a numpy array without raising.
+        Regression: previously .numpy() was called without .detach() and raised.
+        """
+        decoder_model = mock.Mock()
+        decoder_model.device = torch.device("cpu")
+
+        engine = TTSInferenceEngine(
+            llama_queue=mock.Mock(),
+            decoder_model=decoder_model,
+            precision=torch.float32,
+            compile=False,
+        )
+        # Simulate DAC output that might require grad when inference_mode is off
+        fake_audio = torch.ones(100, requires_grad=True)
+        engine.decode_vq_tokens = mock.Mock(return_value=fake_audio)
+
+        result = GenerateResponse(
+            action="sample",
+            codes=torch.zeros(10, 5, dtype=torch.long),
+        )
+
+        out = engine.get_audio_segment(result)
+
+        assert isinstance(out, np.ndarray), "get_audio_segment must return numpy array"
+        assert out.shape == (100,)
+        assert out.dtype == np.float32
+        engine.decode_vq_tokens.assert_called_once()

--- a/tests/test_inference_engine.py
+++ b/tests/test_inference_engine.py
@@ -2,6 +2,7 @@
 Tests for inference_engine (get_audio_segment and related).
 Run: pytest tests/test_inference_engine.py -v
 """
+
 import unittest.mock as mock
 
 import numpy as np

--- a/tests/test_text2semantic_streaming.py
+++ b/tests/test_text2semantic_streaming.py
@@ -1,0 +1,254 @@
+"""
+Unit tests for text2semantic inference streaming helpers.
+No model/checkpoint required.
+
+Run from repo root with project venv:
+  uv sync --extra cpu --extra dev && .venv/bin/python -m pytest tests/test_text2semantic_streaming.py -v
+Or: uv run --extra dev pytest tests/test_text2semantic_streaming.py -v  (if uv uses project venv)
+"""
+import unittest.mock as mock
+
+import pytest
+import torch
+
+from fish_speech.models.text2semantic.inference import (
+    _to_normal_tensor,
+    decode_n_tokens,
+    split_text_by_bytes,
+    split_text_by_speaker,
+)
+
+
+class TestSplitTextByBytes:
+    """Tests for split_text_by_bytes (used when no speaker turns, chunk_length controls batching)."""
+
+    def test_empty_or_whitespace_returns_empty(self):
+        assert split_text_by_bytes("", 100) == []
+        assert split_text_by_bytes("   \n", 100) == []
+
+    def test_short_text_single_chunk(self):
+        assert split_text_by_bytes("Hello", 100) == ["Hello"]
+        assert split_text_by_bytes("Hello world.", 50) == ["Hello world."]
+
+    def test_respects_max_bytes(self):
+        text = "a" * 200
+        chunks = split_text_by_bytes(text, 50)
+        assert len(chunks) == 4
+        assert sum(len(c.encode("utf-8")) for c in chunks) == 200
+        assert all(len(c.encode("utf-8")) <= 50 for c in chunks)
+
+    def test_utf8_boundary_no_split_mid_codepoint(self):
+        # Cyrillic "Привет" is 12 bytes in UTF-8; split at 6 could split inside a character
+        text = "Привет"
+        chunks = split_text_by_bytes(text, 6)
+        # Should not raise; chunks should be valid (no replacement chars from bad split)
+        assert "�" not in "".join(chunks)
+        assert "".join(chunks) == text
+
+    def test_ascii_splits_at_boundary(self):
+        text = "one two three four"
+        chunks = split_text_by_bytes(text, 8)
+        assert all(len(c.encode("utf-8")) <= 8 for c in chunks)
+        assert "".join(chunks) == text
+
+
+class TestSplitTextBySpeaker:
+    """Smoke tests for split_text_by_speaker (used for turn-based batching)."""
+
+    def test_no_speaker_tags_returns_empty_list(self):
+        # No tags -> empty list (caller uses split_text_by_bytes)
+        result = split_text_by_speaker("Just some text.")
+        assert result == []
+
+    def test_with_speaker_tag(self):
+        text = "<|speaker:0|>Hello world."
+        result = split_text_by_speaker(text)
+        assert len(result) >= 1
+        assert any("Hello" in r for r in result)
+
+
+def _is_inference(t: torch.Tensor) -> bool:
+    """True if tensor is an inference tensor (PyTorch 2.5+)."""
+    fn = getattr(t, "is_inference", None)
+    return fn() if callable(fn) else False
+
+
+class TestToNormalTensor:
+    """Tests for _to_normal_tensor (streaming + torch.compile workaround)."""
+
+    def test_returns_copy_on_same_device(self):
+        t = torch.tensor([1.0, 2.0])
+        out = _to_normal_tensor(t)
+        assert out.device == t.device
+        assert out.shape == t.shape
+        assert torch.equal(out, t)
+        assert out is not t
+
+    def test_cuda_if_available(self):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        t = torch.tensor([1.0, 2.0], device="cuda")
+        out = _to_normal_tensor(t)
+        assert out.device.type == "cuda"
+        assert torch.equal(out.cpu(), t.cpu())
+
+    def test_clears_inference_flag_when_called_from_inference_mode(self):
+        """
+        When called from inside inference_mode(), result must not be an inference tensor.
+        This is required so AOT-compiled decode_one_token does not get inference tensors
+        as inputs (runtime does original_inpt.copy_(updated_inpt) and fails on inference tensors).
+        """
+        with torch.inference_mode():
+            t = torch.tensor([1.0, 2.0])
+            out = _to_normal_tensor(t)
+        assert out is not None
+        assert torch.equal(out, t)
+        if hasattr(out, "is_inference") and callable(out.is_inference):
+            assert not out.is_inference(), "_to_normal_tensor must return a normal tensor when used under inference_mode"
+
+
+class TestDecodeNTokens:
+    """Tests for decode_n_tokens loop: chunking, EOS, and streaming vs non-streaming."""
+
+    @pytest.fixture
+    def mock_model(self):
+        """Minimal mock model for decode_n_tokens (config + tokenizer)."""
+        model = mock.Mock()
+        model.config.num_codebooks = 10
+        model.tokenizer.get_token_id = mock.Mock(return_value=99999)  # EOS id
+        return model
+
+    def _make_inputs(self, device="cpu", seq_len=1):
+        codebook_dim = 11  # 1 + num_codebooks
+        cur_token = torch.randint(0, 100, (1, codebook_dim, seq_len), device=device, dtype=torch.long)
+        input_pos = torch.tensor([0], device=device, dtype=torch.long)
+        temperature = torch.tensor(0.7, device=device)
+        top_p = torch.tensor(0.8, device=device)
+        semantic_logit_bias = torch.zeros(1, 1, 100, device=device)
+        return cur_token, input_pos, temperature, top_p, semantic_logit_bias
+
+    @mock.patch("fish_speech.models.text2semantic.inference.tqdm", lambda x: x)
+    def test_streaming_yields_chunks_of_requested_size(self, mock_model):
+        """With stream_chunk_size=5 and mock returning 12 tokens then EOS, we get chunks [5, 5, 2]."""
+        cur_token, input_pos, temperature, top_p, semantic_logit_bias = self._make_inputs()
+        EOS_ID = 99999
+        num_codebooks = 10
+        chunk_size = 5
+        tokens_to_generate = 12  # then EOS
+
+        call_count = 0
+
+        def fake_decode_one_token(*, model, x, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # Return (1, 11, 1) token; last one has EOS at [0,0,0] to stop loop
+            out = torch.randint(1, 100, (1, num_codebooks + 1, 1), dtype=torch.long)
+            if call_count >= tokens_to_generate:
+                out[0, 0, 0] = EOS_ID
+            return out
+
+        with mock.patch("fish_speech.models.text2semantic.inference.logger"):
+            chunks = list(
+                decode_n_tokens(
+                    mock_model,
+                    cur_token,
+                    input_pos,
+                    num_new_tokens=100,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=30,
+                    semantic_logit_bias=semantic_logit_bias,
+                    audio_masks=None,
+                    audio_parts=None,
+                    decode_one_token=fake_decode_one_token,
+                    stream_chunk_size=chunk_size,
+                )
+            )
+
+        # decode_n_tokens cat's on dim=1: each token (1, 11, 1) -> chunk (1, 11*K, 1)
+        assert len(chunks) == 3, "Expected 3 chunks: 5 + 5 + 2"
+        codebook_dim = 11
+        assert chunks[0].shape == (1, codebook_dim * chunk_size, 1)
+        assert chunks[1].shape == (1, codebook_dim * chunk_size, 1)
+        assert chunks[2].shape == (1, codebook_dim * 2, 1)
+        assert call_count == tokens_to_generate
+
+    @mock.patch("fish_speech.models.text2semantic.inference.tqdm", lambda x: x)
+    def test_non_streaming_yields_single_chunk(self, mock_model):
+        """With stream_chunk_size=None we get one chunk with all generated tokens."""
+        cur_token, input_pos, temperature, top_p, semantic_logit_bias = self._make_inputs()
+        EOS_ID = 99999
+        num_codebooks = 10
+        total_tokens = 7
+
+        call_count = 0
+
+        def fake_decode_one_token(*, model, x, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            out = torch.randint(1, 100, (1, num_codebooks + 1, 1), dtype=torch.long)
+            if call_count >= total_tokens:
+                out[0, 0, 0] = EOS_ID
+            return out
+
+        with mock.patch("fish_speech.models.text2semantic.inference.logger"):
+            chunks = list(
+                decode_n_tokens(
+                    mock_model,
+                    cur_token,
+                    input_pos,
+                    num_new_tokens=100,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=30,
+                    semantic_logit_bias=semantic_logit_bias,
+                    audio_masks=None,
+                    audio_parts=None,
+                    decode_one_token=fake_decode_one_token,
+                    stream_chunk_size=None,
+                )
+            )
+
+        # Non-streaming: one chunk (1, 11*K, 1)
+        assert len(chunks) == 1
+        assert chunks[0].shape == (1, 11 * total_tokens, 1)
+        assert call_count == total_tokens
+
+    @mock.patch("fish_speech.models.text2semantic.inference.tqdm", lambda x: x)
+    def test_streaming_eos_before_full_chunk(self, mock_model):
+        """EOS after 2 tokens with stream_chunk_size=5 yields one remainder chunk of 2."""
+        cur_token, input_pos, temperature, top_p, semantic_logit_bias = self._make_inputs()
+        EOS_ID = 99999
+        num_codebooks = 10
+
+        call_count = 0
+
+        def fake_decode_one_token(*, model, x, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            out = torch.randint(1, 100, (1, num_codebooks + 1, 1), dtype=torch.long)
+            if call_count >= 2:
+                out[0, 0, 0] = EOS_ID
+            return out
+
+        with mock.patch("fish_speech.models.text2semantic.inference.logger"):
+            chunks = list(
+                decode_n_tokens(
+                    mock_model,
+                    cur_token,
+                    input_pos,
+                    num_new_tokens=100,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=30,
+                    semantic_logit_bias=semantic_logit_bias,
+                    audio_masks=None,
+                    audio_parts=None,
+                    decode_one_token=fake_decode_one_token,
+                    stream_chunk_size=5,
+                )
+            )
+
+        assert len(chunks) == 1
+        assert chunks[0].shape == (1, 11 * 2, 1)
+        assert call_count == 2

--- a/tests/test_text2semantic_streaming.py
+++ b/tests/test_text2semantic_streaming.py
@@ -6,6 +6,7 @@ Run from repo root with project venv:
   uv sync --extra cpu --extra dev && .venv/bin/python -m pytest tests/test_text2semantic_streaming.py -v
 Or: uv run --extra dev pytest tests/test_text2semantic_streaming.py -v  (if uv uses project venv)
 """
+
 import unittest.mock as mock
 
 import pytest
@@ -104,7 +105,9 @@ class TestToNormalTensor:
         assert out is not None
         assert torch.equal(out, t)
         if hasattr(out, "is_inference") and callable(out.is_inference):
-            assert not out.is_inference(), "_to_normal_tensor must return a normal tensor when used under inference_mode"
+            assert (
+                not out.is_inference()
+            ), "_to_normal_tensor must return a normal tensor when used under inference_mode"
 
 
 class TestDecodeNTokens:
@@ -120,7 +123,9 @@ class TestDecodeNTokens:
 
     def _make_inputs(self, device="cpu", seq_len=1):
         codebook_dim = 11  # 1 + num_codebooks
-        cur_token = torch.randint(0, 100, (1, codebook_dim, seq_len), device=device, dtype=torch.long)
+        cur_token = torch.randint(
+            0, 100, (1, codebook_dim, seq_len), device=device, dtype=torch.long
+        )
         input_pos = torch.tensor([0], device=device, dtype=torch.long)
         temperature = torch.tensor(0.7, device=device)
         top_p = torch.tensor(0.8, device=device)
@@ -130,7 +135,9 @@ class TestDecodeNTokens:
     @mock.patch("fish_speech.models.text2semantic.inference.tqdm", lambda x: x)
     def test_streaming_yields_chunks_of_requested_size(self, mock_model):
         """With stream_chunk_size=5 and mock returning 12 tokens then EOS, we get chunks [5, 5, 2]."""
-        cur_token, input_pos, temperature, top_p, semantic_logit_bias = self._make_inputs()
+        cur_token, input_pos, temperature, top_p, semantic_logit_bias = (
+            self._make_inputs()
+        )
         EOS_ID = 99999
         num_codebooks = 10
         chunk_size = 5
@@ -176,7 +183,9 @@ class TestDecodeNTokens:
     @mock.patch("fish_speech.models.text2semantic.inference.tqdm", lambda x: x)
     def test_non_streaming_yields_single_chunk(self, mock_model):
         """With stream_chunk_size=None we get one chunk with all generated tokens."""
-        cur_token, input_pos, temperature, top_p, semantic_logit_bias = self._make_inputs()
+        cur_token, input_pos, temperature, top_p, semantic_logit_bias = (
+            self._make_inputs()
+        )
         EOS_ID = 99999
         num_codebooks = 10
         total_tokens = 7
@@ -217,7 +226,9 @@ class TestDecodeNTokens:
     @mock.patch("fish_speech.models.text2semantic.inference.tqdm", lambda x: x)
     def test_streaming_eos_before_full_chunk(self, mock_model):
         """EOS after 2 tokens with stream_chunk_size=5 yields one remainder chunk of 2."""
-        cur_token, input_pos, temperature, top_p, semantic_logit_bias = self._make_inputs()
+        cur_token, input_pos, temperature, top_p, semantic_logit_bias = (
+            self._make_inputs()
+        )
         EOS_ID = 99999
         num_codebooks = 10
 

--- a/tools/api_server.py
+++ b/tools/api_server.py
@@ -1,5 +1,15 @@
 import re
+import warnings
 from threading import Lock
+
+# Suppress torch.compile (Inductor) spam: "Logical operators 'and'/'or' deprecated, use '&'/'|'"
+# Source: torch._inductor.runtime.triton_helpers — fix belongs in PyTorch upstream
+warnings.filterwarnings(
+    "ignore",
+    message=".*Logical operators 'and' and 'or' are deprecated for non-scalar tensors.*",
+    category=UserWarning,
+    module="torch._inductor",
+)
 
 import pyrootutils
 import uvicorn

--- a/tools/memory_metrics.py
+++ b/tools/memory_metrics.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Poll /v1/debug/memory at a fixed interval; append one JSON line only when metrics change.
+Usage:
+  python tools/memory_metrics.py
+  python tools/memory_metrics.py --interval 0.25 --out metrics.jsonl
+  python tools/memory_metrics.py --all   # write every sample (no change filter)
+Stop with Ctrl+C.
+"""
+import argparse
+import json
+import sys
+import time
+import urllib.request
+
+
+def main():
+    p = argparse.ArgumentParser(description="Log GPU memory metrics to a JSONL file (on change)")
+    p.add_argument(
+        "--url",
+        default="http://127.0.0.1:18081/v1/debug/memory",
+        help="Debug memory endpoint URL",
+    )
+    p.add_argument(
+        "--interval",
+        type=float,
+        default=0.25,
+        help="Sample interval in seconds (default: 0.25)",
+    )
+    p.add_argument(
+        "--out",
+        default="memory_metrics.jsonl",
+        help="Output JSONL file (default: memory_metrics.jsonl)",
+    )
+    p.add_argument(
+        "--all",
+        action="store_true",
+        help="Write every sample; default is only when allocated/reserved/max change",
+    )
+    args = p.parse_args()
+
+    req = urllib.request.Request(args.url)
+    line_count = 0
+    last_key = None
+    try:
+        with open(args.out, "a") as f:
+            while True:
+                try:
+                    with urllib.request.urlopen(req, timeout=5) as r:
+                        data = json.loads(r.read().decode())
+                except Exception as e:
+                    print(f"{time.time():.0f} error: {e}", file=sys.stderr)
+                    time.sleep(args.interval)
+                    continue
+                ts = time.time()
+                row = {
+                    "ts": ts,
+                    "allocated_gb": data.get("allocated_gb"),
+                    "reserved_gb": data.get("reserved_gb"),
+                    "max_allocated_gb": data.get("max_allocated_gb"),
+                }
+                if "models" in data:
+                    row["models"] = data["models"]
+                key = (row["allocated_gb"], row["reserved_gb"], row["max_allocated_gb"])
+                if args.all or key != last_key:
+                    last_key = key
+                    f.write(json.dumps(row) + "\n")
+                    f.flush()
+                    line_count += 1
+                    print(f"{ts:.0f} alloc={row['allocated_gb']} reserved={row['reserved_gb']} max={row['max_allocated_gb']} GB", file=sys.stderr)
+                time.sleep(args.interval)
+    except KeyboardInterrupt:
+        print(f"\nStopped. Wrote {line_count} lines to {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/memory_metrics.py
+++ b/tools/memory_metrics.py
@@ -7,6 +7,7 @@ Usage:
   python tools/memory_metrics.py --all   # write every sample (no change filter)
 Stop with Ctrl+C.
 """
+
 import argparse
 import json
 import sys
@@ -15,7 +16,9 @@ import urllib.request
 
 
 def main():
-    p = argparse.ArgumentParser(description="Log GPU memory metrics to a JSONL file (on change)")
+    p = argparse.ArgumentParser(
+        description="Log GPU memory metrics to a JSONL file (on change)"
+    )
     p.add_argument(
         "--url",
         default="http://127.0.0.1:18081/v1/debug/memory",
@@ -67,7 +70,10 @@ def main():
                     f.write(json.dumps(row) + "\n")
                     f.flush()
                     line_count += 1
-                    print(f"{ts:.0f} alloc={row['allocated_gb']} reserved={row['reserved_gb']} max={row['max_allocated_gb']} GB", file=sys.stderr)
+                    print(
+                        f"{ts:.0f} alloc={row['allocated_gb']} reserved={row['reserved_gb']} max={row['max_allocated_gb']} GB",
+                        file=sys.stderr,
+                    )
                 time.sleep(args.interval)
     except KeyboardInterrupt:
         print(f"\nStopped. Wrote {line_count} lines to {args.out}", file=sys.stderr)

--- a/tools/preencode_references.py
+++ b/tools/preencode_references.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Pre-encode reference audio to .codes.pt so the server skips DAC encode at runtime.
+Reads a folder of *.wav + *.txt (same stem), runs DAC encoder once per file (sequential).
+
+Without --ref-id: one reference per file, ID = stem.  ru.wav + ru.txt -> references/ru/ru.codes.pt, ru.lab
+With --ref-id: all files under one reference.  -> references/<ref_id>/<stem>.codes.pt, <stem>.lab
+
+With --upload: after writing each reference, POST to server /v1/references/add_encoded. Server skips
+write if content hash matches (unchanged). Requires server to be running.
+
+  python tools/preencode_references.py --input-dir ./data/voice_references
+  python tools/preencode_references.py --input-dir ./data/voice_references --upload --server-url http://127.0.0.1:8080
+"""
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import click
+import torch
+import torchaudio
+from loguru import logger
+
+from fish_speech.utils.file import AUDIO_EXTENSIONS
+from fish_speech.models.dac.inference import load_model as load_dac_model
+
+
+def _upload_encoded(
+    server_url: str, ref_id: str, codes_path: Path, lab_path: Path, stem: str | None = None
+) -> None:
+    """POST pre-encoded reference to server. Server skips if hash matches."""
+    stem = stem or ref_id
+    codes_bytes = codes_path.read_bytes()
+    lab_text = lab_path.read_text(encoding="utf-8")
+    url = f"{server_url.rstrip('/')}/v1/references/add_encoded"
+    boundary = "----form-boundary----"
+    body_parts = [
+        f'--{boundary}\r\nContent-Disposition: form-data; name="id"\r\n\r\n{ref_id}\r\n',
+        f'--{boundary}\r\nContent-Disposition: form-data; name="stem"\r\n\r\n{stem}\r\n',
+        f'--{boundary}\r\nContent-Disposition: form-data; name="codes"; filename="{stem}.codes.pt"\r\nContent-Type: application/octet-stream\r\n\r\n',
+        codes_bytes,
+        b"\r\n",
+        f'--{boundary}\r\nContent-Disposition: form-data; name="lab"; filename="{stem}.lab"\r\nContent-Type: text/plain\r\n\r\n',
+        lab_text.encode("utf-8"),
+        b"\r\n",
+        f"--{boundary}--\r\n",
+    ]
+    body = b""
+    for p in body_parts:
+        body = body + (p if isinstance(p, bytes) else p.encode("utf-8"))
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+    req.add_header("Content-Length", str(len(body)))
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            data = r.read().decode("utf-8")
+            logger.info("Upload {}/{}: {}", ref_id, stem, data)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        logger.warning("Upload {}/{} failed: {} {}", ref_id, stem, e.code, body)
+    except Exception as e:
+        logger.warning("Upload {}/{} error: {}", ref_id, stem, e)
+
+
+@click.command()
+@click.option(
+    "--input-dir",
+    "-i",
+    type=click.Path(exists=True, path_type=Path),
+    required=False,
+    default=None,
+    help="Folder with pairs: <stem>.wav + <stem>.txt (or .lab). Not needed with --upload-only.",
+)
+@click.option(
+    "--ref-id",
+    "-r",
+    default=None,
+    help="Reference ID. If omitted, ID = stem per file (ru.wav -> references/ru/). If set, all files go under <output-dir>/<ref_id>/",
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    default="references",
+    type=click.Path(path_type=Path),
+    help="Base dir for references (default: references). Result: <output-dir>/<ref_id>/",
+)
+@click.option("--config-name", default="modded_dac_vq", help="DAC config name")
+@click.option(
+    "--checkpoint-path",
+    default="checkpoints/s2-pro/codec.pth",
+    type=click.Path(path_type=Path),
+    help="DAC checkpoint",
+)
+@click.option(
+    "--device",
+    "-d",
+    default="cpu",
+    type=click.Choice(["cpu", "cuda", "cuda:0"]),
+    help="Device for encode (cpu = no VRAM spike, one file at a time)",
+)
+@click.option(
+    "--upload",
+    is_flag=True,
+    help="After encoding, upload each reference to server (POST /v1/references/add_encoded). Server skips if hash matches.",
+)
+@click.option(
+    "--server-url",
+    default="http://127.0.0.1:8080",
+    help="Server base URL for --upload (default: http://127.0.0.1:8080)",
+)
+@click.option(
+    "--upload-only",
+    is_flag=True,
+    help="Only upload existing references/ (no encoding). Scan output-dir for *.codes.pt + *.lab and POST each. No DAC, no input-dir.",
+)
+def main(
+    input_dir: Path,
+    ref_id: str | None,
+    output_dir: Path,
+    config_name: str,
+    checkpoint_path: Path,
+    device: str,
+    upload: bool,
+    server_url: str,
+    upload_only: bool,
+) -> None:
+    base_out = Path(output_dir).resolve()
+
+    if upload_only:
+        # Scan base_out for ref_id dirs, each with *.codes.pt + *.lab; upload without encoding
+        if not base_out.exists():
+            logger.error("Output dir %s not found", base_out)
+            raise SystemExit(1)
+        for ref_dir in sorted(base_out.iterdir()):
+            if not ref_dir.is_dir():
+                continue
+            ref_id_name = ref_dir.name
+            for codes_path in sorted(ref_dir.glob("*.codes.pt")):
+                stem = codes_path.stem.removesuffix(".codes") if codes_path.stem.endswith(".codes") else codes_path.stem
+                lab_path = ref_dir / f"{stem}.lab"
+                if not lab_path.exists():
+                    logger.warning("No %s for %s, skip", lab_path.name, codes_path.name)
+                    continue
+                logger.info("Upload only: %s/%s", ref_id_name, stem)
+                _upload_encoded(server_url, ref_id_name, codes_path, lab_path, stem=stem)
+        logger.info("Upload-only done for %s", base_out)
+        return
+
+    if input_dir is None:
+        raise click.UsageError("--input-dir required unless --upload-only")
+    input_dir = input_dir.resolve()
+
+    # Find stems that have both .wav and .txt (or .lab)
+    wavs = {
+        p.stem: p
+        for p in input_dir.iterdir()
+        if p.suffix.lower() in AUDIO_EXTENSIONS and p.is_file()
+    }
+    stems = []
+    for stem, wav_path in sorted(wavs.items()):
+        txt = input_dir / f"{stem}.txt"
+        lab = input_dir / f"{stem}.lab"
+        if txt.exists():
+            text_path = txt
+        elif lab.exists():
+            text_path = lab
+        else:
+            logger.warning("No .txt/.lab for {}, skipping", stem)
+            continue
+        stems.append((stem, wav_path, text_path))
+
+    if not stems:
+        logger.error("No (wav + txt/lab) pairs in {}", input_dir)
+        raise SystemExit(1)
+
+    # One ref_id per file (ID = stem) or one folder for all
+    use_stem_as_id = ref_id is None
+    if use_stem_as_id:
+        logger.info("Output: {} (one reference per file, ID = stem)", base_out)
+    else:
+        ref_folder = base_out / ref_id
+        ref_folder.mkdir(parents=True, exist_ok=True)
+        logger.info("Output: {}", ref_folder)
+
+    logger.info("Loading DAC once (device={})...", device)
+    model = load_dac_model(
+        config_name=config_name,
+        checkpoint_path=str(checkpoint_path),
+        device=device,
+    )
+
+    for stem, wav_path, text_path in stems:
+        ref_folder = base_out / (stem if use_stem_as_id else ref_id)
+        ref_folder.mkdir(parents=True, exist_ok=True)
+        logger.info("Encoding {} -> {} (id={})", stem, ref_folder, stem if use_stem_as_id else ref_id)
+        audio, sr = torchaudio.load(str(wav_path))
+        if audio.shape[0] > 1:
+            audio = audio.mean(0, keepdim=True)
+        audio = torchaudio.functional.resample(audio, sr, model.sample_rate)
+        audios = audio[None].to(device)  # (1, 1, T)
+        audio_lengths = torch.tensor([audios.shape[2]], device=device, dtype=torch.long)
+        with torch.no_grad():
+            indices, _ = model.encode(audios, audio_lengths)
+        if indices.ndim == 3:
+            indices = indices[0]  # (num_codebooks, T)
+        codes_path = ref_folder / f"{stem}.codes.pt"
+        torch.save(indices.cpu(), codes_path)
+        lab_text = text_path.read_text(encoding="utf-8")
+        lab_path = ref_folder / f"{stem}.lab"
+        lab_path.write_text(lab_text, encoding="utf-8")
+
+        if upload:
+            ref_id_for_upload = stem if use_stem_as_id else ref_id
+            stem_for_upload = stem
+            _upload_encoded(server_url, ref_id_for_upload, codes_path, lab_path, stem=stem_for_upload)
+
+    logger.info("Done. {} reference(s) in {}", len(stems), base_out)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/preencode_references.py
+++ b/tools/preencode_references.py
@@ -12,6 +12,7 @@ write if content hash matches (unchanged). Requires server to be running.
   python tools/preencode_references.py --input-dir ./data/voice_references
   python tools/preencode_references.py --input-dir ./data/voice_references --upload --server-url http://127.0.0.1:8080
 """
+
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -21,12 +22,16 @@ import torch
 import torchaudio
 from loguru import logger
 
-from fish_speech.utils.file import AUDIO_EXTENSIONS
 from fish_speech.models.dac.inference import load_model as load_dac_model
+from fish_speech.utils.file import AUDIO_EXTENSIONS
 
 
 def _upload_encoded(
-    server_url: str, ref_id: str, codes_path: Path, lab_path: Path, stem: str | None = None
+    server_url: str,
+    ref_id: str,
+    codes_path: Path,
+    lab_path: Path,
+    stem: str | None = None,
 ) -> None:
     """POST pre-encoded reference to server. Server skips if hash matches."""
     stem = stem or ref_id
@@ -136,13 +141,19 @@ def main(
                 continue
             ref_id_name = ref_dir.name
             for codes_path in sorted(ref_dir.glob("*.codes.pt")):
-                stem = codes_path.stem.removesuffix(".codes") if codes_path.stem.endswith(".codes") else codes_path.stem
+                stem = (
+                    codes_path.stem.removesuffix(".codes")
+                    if codes_path.stem.endswith(".codes")
+                    else codes_path.stem
+                )
                 lab_path = ref_dir / f"{stem}.lab"
                 if not lab_path.exists():
                     logger.warning("No %s for %s, skip", lab_path.name, codes_path.name)
                     continue
                 logger.info("Upload only: %s/%s", ref_id_name, stem)
-                _upload_encoded(server_url, ref_id_name, codes_path, lab_path, stem=stem)
+                _upload_encoded(
+                    server_url, ref_id_name, codes_path, lab_path, stem=stem
+                )
         logger.info("Upload-only done for %s", base_out)
         return
 
@@ -192,7 +203,12 @@ def main(
     for stem, wav_path, text_path in stems:
         ref_folder = base_out / (stem if use_stem_as_id else ref_id)
         ref_folder.mkdir(parents=True, exist_ok=True)
-        logger.info("Encoding {} -> {} (id={})", stem, ref_folder, stem if use_stem_as_id else ref_id)
+        logger.info(
+            "Encoding {} -> {} (id={})",
+            stem,
+            ref_folder,
+            stem if use_stem_as_id else ref_id,
+        )
         audio, sr = torchaudio.load(str(wav_path))
         if audio.shape[0] > 1:
             audio = audio.mean(0, keepdim=True)
@@ -212,7 +228,13 @@ def main(
         if upload:
             ref_id_for_upload = stem if use_stem_as_id else ref_id
             stem_for_upload = stem
-            _upload_encoded(server_url, ref_id_for_upload, codes_path, lab_path, stem=stem_for_upload)
+            _upload_encoded(
+                server_url,
+                ref_id_for_upload,
+                codes_path,
+                lab_path,
+                stem=stem_for_upload,
+            )
 
     logger.info("Done. {} reference(s) in {}", len(stems), base_out)
 

--- a/tools/server/inference.py
+++ b/tools/server/inference.py
@@ -19,7 +19,11 @@ def inference_wrapper(req: ServeTTSRequest, engine: TTSInferenceEngine):
         match result.code:
             case "header":
                 if isinstance(result.audio, tuple):
-                    yield result.audio[1]
+                    header = result.audio[1]
+                    if isinstance(header, np.ndarray):
+                        yield header.tobytes()
+                    elif isinstance(header, (bytes, bytearray)):
+                        yield bytes(header)
 
             case "error":
                 raise HTTPException(
@@ -35,7 +39,11 @@ def inference_wrapper(req: ServeTTSRequest, engine: TTSInferenceEngine):
             case "final":
                 count += 1
                 if isinstance(result.audio, tuple):
-                    yield result.audio[1]
+                    final = result.audio[1]
+                    if isinstance(final, np.ndarray):
+                        yield (final * AMPLITUDE).astype(np.int16).tobytes()
+                    elif isinstance(final, (bytes, bytearray)):
+                        yield bytes(final)
                 return None  # Stop the generator
 
     if count == 0:

--- a/tools/server/model_manager.py
+++ b/tools/server/model_manager.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 from loguru import logger
 
@@ -35,6 +37,8 @@ class ModelManager:
             self.device = "cpu"
             logger.info("CUDA is not available, running on CPU.")
 
+        # Shared dict for worker to report LLM param memory (see /v1/debug/memory).
+        self._worker_memory_info = {}
         # Load the TTS models
         self.load_llama_model(
             llama_checkpoint_path, self.device, self.precision, self.compile, self.mode
@@ -49,9 +53,18 @@ class ModelManager:
             compile=self.compile,
         )
 
-        # Warm up the models
-        if self.mode == "tts":
-            self.warm_up(self.tts_inference_engine)
+        # Optional: record CUDA alloc/free history for debugging (dump via GET /v1/debug/memory?dump=1).
+        if torch.cuda.is_available() and os.environ.get("FISH_RECORD_MEMORY_HISTORY", "").strip() in ("1", "true", "True"):
+            try:
+                max_entries = int(os.environ.get("FISH_MEMORY_HISTORY_MAX_ENTRIES", "100000"))
+                torch.cuda.memory._record_memory_history(max_entries=max_entries)
+                logger.info("CUDA memory history recording enabled (max_entries=%s); use ?dump=1 on /v1/debug/memory to save snapshot", max_entries)
+            except Exception as e:
+                logger.warning("Could not enable CUDA memory history recording: %s", e)
+
+        # When --compile: run warmup before accepting requests so /v1/health "ready" = compiled.
+        if self.mode == "tts" and self.compile:
+            self.warm_up(self.tts_inference_engine, compile=True)
 
     def load_llama_model(
         self, checkpoint_path, device, precision, compile, mode
@@ -63,6 +76,7 @@ class ModelManager:
                 device=device,
                 precision=precision,
                 compile=compile,
+                memory_info=self._worker_memory_info,
             )
         else:
             raise ValueError(f"Invalid mode: {mode}")
@@ -77,12 +91,20 @@ class ModelManager:
         )
         logger.info("Decoder model loaded.")
 
-    def warm_up(self, tts_inference_engine) -> None:
+    def warm_up(self, tts_inference_engine, *, compile: bool = False) -> None:
+        # Compilation is per input shape: short prompt (warmup) compiles one graph; first
+        # request with long prompt (e.g. reference) compiles another → second delay.
+        # Use small max_new_tokens on warmup to reduce peak VRAM (fits ~32 GB with compile).
+        if compile:
+            logger.info(
+                "Warmup: running first inference (triggers torch.compile/Inductor; "
+                "may take 2-10+ min on first run, then fast)."
+            )
         request = ServeTTSRequest(
             text="Hello world.",
             references=[],
             reference_id=None,
-            max_new_tokens=1024,
+            max_new_tokens=64,  # was 1024; lower = less VRAM during compile, still triggers graph
             chunk_length=200,
             top_p=0.7,
             repetition_penalty=1.2,
@@ -90,4 +112,39 @@ class ModelManager:
             format="wav",
         )
         list(inference(request, tts_inference_engine))
-        logger.info("Models warmed up.")
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()  # free cached VRAM so first request with reference fits in 32 GB
+        logger.info("Warmup done.")
+
+        # Optional: compile the long-prompt + streaming path so first real request is fast.
+        # Set FISH_WARMUP_REFERENCE_ID to a valid reference id (e.g. en) to run one
+        # streaming request with that reference at startup. Use ~50 word text so the
+        # compiled graph covers typical range (Hello world .. 50 words) and avoids
+        # recompile on first user request.
+        warmup_ref = os.environ.get("FISH_WARMUP_REFERENCE_ID", "").strip()
+        if compile and warmup_ref:
+            # Text ~50 words so prompt length is in "typical long" range; one compile covers short..long.
+            warmup_long_text = (
+                "Hello, this is a longer warmup so the compiled graph covers prompts from a few words "
+                "to about fifty. We run this once at startup to avoid recompiling on the first real request."
+            )
+            logger.info(
+                "Warmup: running streaming inference with reference_id=%s (long prompt compile, ~50 words)",
+                warmup_ref,
+            )
+            request_long = ServeTTSRequest(
+                text=warmup_long_text,
+                references=[],
+                reference_id=warmup_ref,
+                max_new_tokens=64,
+                chunk_length=200,
+                top_p=0.7,
+                repetition_penalty=1.2,
+                temperature=0.7,
+                format="wav",
+                streaming=True,
+            )
+            list(inference(request_long, tts_inference_engine))
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            logger.info("Warmup (long prompt + streaming) done.")

--- a/tools/server/model_manager.py
+++ b/tools/server/model_manager.py
@@ -54,11 +54,18 @@ class ModelManager:
         )
 
         # Optional: record CUDA alloc/free history for debugging (dump via GET /v1/debug/memory?dump=1).
-        if torch.cuda.is_available() and os.environ.get("FISH_RECORD_MEMORY_HISTORY", "").strip() in ("1", "true", "True"):
+        if torch.cuda.is_available() and os.environ.get(
+            "FISH_RECORD_MEMORY_HISTORY", ""
+        ).strip() in ("1", "true", "True"):
             try:
-                max_entries = int(os.environ.get("FISH_MEMORY_HISTORY_MAX_ENTRIES", "100000"))
+                max_entries = int(
+                    os.environ.get("FISH_MEMORY_HISTORY_MAX_ENTRIES", "100000")
+                )
                 torch.cuda.memory._record_memory_history(max_entries=max_entries)
-                logger.info("CUDA memory history recording enabled (max_entries=%s); use ?dump=1 on /v1/debug/memory to save snapshot", max_entries)
+                logger.info(
+                    "CUDA memory history recording enabled (max_entries=%s); use ?dump=1 on /v1/debug/memory to save snapshot",
+                    max_entries,
+                )
             except Exception as e:
                 logger.warning("Could not enable CUDA memory history recording: %s", e)
 

--- a/tools/server/model_manager.py
+++ b/tools/server/model_manager.py
@@ -71,7 +71,12 @@ class ModelManager:
 
         # When --compile: run warmup before accepting requests so /v1/health "ready" = compiled.
         if self.mode == "tts" and self.compile:
+            logger.warning(
+                "torch.compile enabled — running warmup now (Inductor compiles kernels; typically 2–10 min). "
+                "Server will accept connections after this."
+            )
             self.warm_up(self.tts_inference_engine, compile=True)
+            logger.warning("torch.compile warmup finished — server ready.")
 
     def load_llama_model(
         self, checkpoint_path, device, precision, compile, mode
@@ -104,8 +109,8 @@ class ModelManager:
         # Use small max_new_tokens on warmup to reduce peak VRAM (fits ~32 GB with compile).
         if compile:
             logger.info(
-                "Warmup: running first inference (triggers torch.compile/Inductor; "
-                "may take 2-10+ min on first run, then fast)."
+                "Warmup: first inference (triggers torch.compile/Inductor; "
+                "compiling kernels — can take 2–10+ min, then requests are fast)."
             )
         request = ServeTTSRequest(
             text="Hello world.",
@@ -121,7 +126,7 @@ class ModelManager:
         list(inference(request, tts_inference_engine))
         if torch.cuda.is_available():
             torch.cuda.empty_cache()  # free cached VRAM so first request with reference fits in 32 GB
-        logger.info("Warmup done.")
+        logger.info("Warmup: first inference done.")
 
         # Optional: compile the long-prompt + streaming path so first real request is fast.
         # Set FISH_WARMUP_REFERENCE_ID to a valid reference id (e.g. en) to run one

--- a/tools/server/views.py
+++ b/tools/server/views.py
@@ -21,8 +21,8 @@ from kui.asgi import (
     UploadFile,
     request,
 )
-from starlette.responses import Response
 from loguru import logger
+from starlette.responses import Response
 from typing_extensions import Annotated
 
 from fish_speech.utils.schema import (
@@ -88,7 +88,10 @@ def _gpu_memory_info(model_manager: ModelManager | None = None):
     }
     if model_manager is not None:
         models = {}
-        if hasattr(model_manager, "decoder_model") and model_manager.decoder_model is not None:
+        if (
+            hasattr(model_manager, "decoder_model")
+            and model_manager.decoder_model is not None
+        ):
             dac_gb, dac_count = _model_param_memory_gb(model_manager.decoder_model)
             models["dac"] = {"param_gb": dac_gb, "param_count": dac_count}
         if getattr(model_manager, "_worker_memory_info", None):
@@ -104,13 +107,17 @@ def _gpu_memory_info(model_manager: ModelManager | None = None):
         out["devices"] = []
         for i in range(torch.cuda.device_count()):
             with torch.cuda.device(i):
-                out["devices"].append({
-                    "device": i,
-                    "name": torch.cuda.get_device_name(i),
-                    "allocated_gb": round(torch.cuda.memory_allocated() / gb, 3),
-                    "reserved_gb": round(torch.cuda.memory_reserved() / gb, 3),
-                    "max_allocated_gb": round(torch.cuda.max_memory_allocated() / gb, 3),
-                })
+                out["devices"].append(
+                    {
+                        "device": i,
+                        "name": torch.cuda.get_device_name(i),
+                        "allocated_gb": round(torch.cuda.memory_allocated() / gb, 3),
+                        "reserved_gb": round(torch.cuda.memory_reserved() / gb, 3),
+                        "max_allocated_gb": round(
+                            torch.cuda.max_memory_allocated() / gb, 3
+                        ),
+                    }
+                )
     try:
         out["memory_summary"] = torch.cuda.memory_summary(abbreviated=True)
     except Exception:
@@ -133,12 +140,16 @@ def _gpu_memory_text(info: dict) -> str:
     if "models" in info:
         lines.append("Model weights (params only)")
         for name, m in info["models"].items():
-            lines.append(f"  {name}: param_gb={m.get('param_gb')} param_count={m.get('param_count', 'N/A')}")
+            lines.append(
+                f"  {name}: param_gb={m.get('param_gb')} param_count={m.get('param_count', 'N/A')}"
+            )
         lines.append("")
     if "devices" in info:
         for d in info["devices"]:
             lines.append(f"  device {d['device']} ({d['name']})")
-            lines.append(f"    allocated_gb: {d['allocated_gb']}  reserved_gb: {d['reserved_gb']}  max_allocated_gb: {d['max_allocated_gb']}")
+            lines.append(
+                f"    allocated_gb: {d['allocated_gb']}  reserved_gb: {d['reserved_gb']}  max_allocated_gb: {d['max_allocated_gb']}"
+            )
         lines.append("")
     if "memory_summary" in info:
         lines.append(info["memory_summary"])
@@ -158,7 +169,10 @@ def _dump_memory_snapshot(out_dir: str = "/workspace") -> tuple[str | None, str 
         dump_fn(path)
         return path, None
     except Exception as e:
-        return None, f"Dump failed: {e!r} (need PyTorch built with CUDA memory snapshot support?)"
+        return (
+            None,
+            f"Dump failed: {e!r} (need PyTorch built with CUDA memory snapshot support?)",
+        )
 
 
 @routes.http.get("/v1/debug/memory")
@@ -176,9 +190,14 @@ async def debug_memory():
         snapshot_path, snapshot_err = _dump_memory_snapshot(out_dir=out_dir)
         if snapshot_path:
             info["snapshot_path"] = snapshot_path
-            info["snapshot_note"] = "Open at https://pytorch.org/memory_viz or: python -m torch.cuda._memory_viz trace_plot <path> -o out.html"
+            info["snapshot_note"] = (
+                "Open at https://pytorch.org/memory_viz or: python -m torch.cuda._memory_viz trace_plot <path> -o out.html"
+            )
         else:
-            info["snapshot_error"] = snapshot_err or "Set FISH_RECORD_MEMORY_HISTORY=1 at startup for alloc history in snapshot."
+            info["snapshot_error"] = (
+                snapshot_err
+                or "Set FISH_RECORD_MEMORY_HISTORY=1 at startup for alloc history in snapshot."
+            )
     if request.query_params.get("format", "").strip().lower() == "text":
         return Response(_gpu_memory_text(info), media_type="text/plain; charset=utf-8")
     return JSONResponse(info)
@@ -284,7 +303,9 @@ async def tts(req: Annotated[ServeTTSRequest, Body(exclusive=True)]):
             for result in engine.inference(req):
                 if result.code == "error" and result.error:
                     raise RuntimeError(str(result.error))
-                if result.code in ("segment", "final") and isinstance(result.audio, tuple):
+                if result.code in ("segment", "final") and isinstance(
+                    result.audio, tuple
+                ):
                     chunks.append(result.audio[1])
             if not chunks:
                 raise HTTPException(

--- a/tools/server/views.py
+++ b/tools/server/views.py
@@ -21,10 +21,12 @@ from kui.asgi import (
     UploadFile,
     request,
 )
+from starlette.responses import Response
 from loguru import logger
 from typing_extensions import Annotated
 
 from fish_speech.utils.schema import (
+    AddEncodedReferenceResponse,
     AddReferenceRequest,
     AddReferenceResponse,
     DeleteReferenceResponse,
@@ -63,6 +65,123 @@ class Health(HttpView):
     @classmethod
     async def post(cls):
         return JSONResponse({"status": "ok"})
+
+
+def _model_param_memory_gb(module: torch.nn.Module) -> tuple[float, int]:
+    """Weights-only memory (GB) and param count for a module."""
+    total_bytes = sum(p.numel() * p.element_size() for p in module.parameters())
+    count = sum(p.numel() for p in module.parameters())
+    return (round(total_bytes / (1024**3), 3), count)
+
+
+def _gpu_memory_info(model_manager: ModelManager | None = None):
+    """Current GPU memory usage (read-only, safe to call anytime)."""
+    if not torch.cuda.is_available():
+        return {"cuda_available": False}
+    gb = 1024**3
+    out = {
+        "cuda_available": True,
+        "allocated_gb": round(torch.cuda.memory_allocated() / gb, 3),
+        "reserved_gb": round(torch.cuda.memory_reserved() / gb, 3),
+        "max_allocated_gb": round(torch.cuda.max_memory_allocated() / gb, 3),
+        "device_count": torch.cuda.device_count(),
+    }
+    if model_manager is not None:
+        models = {}
+        if hasattr(model_manager, "decoder_model") and model_manager.decoder_model is not None:
+            dac_gb, dac_count = _model_param_memory_gb(model_manager.decoder_model)
+            models["dac"] = {"param_gb": dac_gb, "param_count": dac_count}
+        if getattr(model_manager, "_worker_memory_info", None):
+            wi = model_manager._worker_memory_info
+            if "llama_param_gb" in wi:
+                models["llama"] = {
+                    "param_gb": wi["llama_param_gb"],
+                    "param_count": wi.get("llama_param_count"),
+                }
+        if models:
+            out["models"] = models
+    if torch.cuda.device_count() > 1:
+        out["devices"] = []
+        for i in range(torch.cuda.device_count()):
+            with torch.cuda.device(i):
+                out["devices"].append({
+                    "device": i,
+                    "name": torch.cuda.get_device_name(i),
+                    "allocated_gb": round(torch.cuda.memory_allocated() / gb, 3),
+                    "reserved_gb": round(torch.cuda.memory_reserved() / gb, 3),
+                    "max_allocated_gb": round(torch.cuda.max_memory_allocated() / gb, 3),
+                })
+    try:
+        out["memory_summary"] = torch.cuda.memory_summary(abbreviated=True)
+    except Exception:
+        pass
+    return out
+
+
+def _gpu_memory_text(info: dict) -> str:
+    """Format GPU memory info as plain text (readable table)."""
+    if not info.get("cuda_available"):
+        return "CUDA not available.\n"
+    lines = [
+        "GPU memory (current)",
+        f"  allocated_gb:    {info['allocated_gb']}",
+        f"  reserved_gb:     {info['reserved_gb']}",
+        f"  max_allocated_gb: {info['max_allocated_gb']}",
+        f"  device_count:    {info['device_count']}",
+        "",
+    ]
+    if "models" in info:
+        lines.append("Model weights (params only)")
+        for name, m in info["models"].items():
+            lines.append(f"  {name}: param_gb={m.get('param_gb')} param_count={m.get('param_count', 'N/A')}")
+        lines.append("")
+    if "devices" in info:
+        for d in info["devices"]:
+            lines.append(f"  device {d['device']} ({d['name']})")
+            lines.append(f"    allocated_gb: {d['allocated_gb']}  reserved_gb: {d['reserved_gb']}  max_allocated_gb: {d['max_allocated_gb']}")
+        lines.append("")
+    if "memory_summary" in info:
+        lines.append(info["memory_summary"])
+    return "\n".join(lines)
+
+
+def _dump_memory_snapshot(out_dir: str = "/workspace") -> tuple[str | None, str | None]:
+    """Dump current CUDA memory snapshot to a pickle file. Returns (path, None) or (None, error_message)."""
+    if not torch.cuda.is_available():
+        return None, "CUDA not available"
+    dump_fn = getattr(torch.cuda.memory, "_dump_snapshot", None)
+    if dump_fn is None:
+        return None, "_dump_snapshot not found (PyTorch too old?)"
+    try:
+        Path(out_dir).mkdir(parents=True, exist_ok=True)
+        path = os.path.join(out_dir, f"memory_snapshot_{int(time.time())}.pickle")
+        dump_fn(path)
+        return path, None
+    except Exception as e:
+        return None, f"Dump failed: {e!r} (need PyTorch built with CUDA memory snapshot support?)"
+
+
+@routes.http.get("/v1/debug/memory")
+async def debug_memory():
+    """
+    Return current GPU memory usage (allocated, reserved, max).
+    If model_manager is available, includes models.dac and models.llama param memory (weights only).
+    Query: ?format=text for plain text (table aligned), default JSON.
+    Query: ?dump=1 to also write torch.cuda.memory._dump_snapshot() to /workspace (requires FISH_RECORD_MEMORY_HISTORY=1 at startup).
+    """
+    model_manager = getattr(request.app.state, "model_manager", None)
+    info = _gpu_memory_info(model_manager)
+    if request.query_params.get("dump", "").strip() in ("1", "true", "True"):
+        out_dir = request.query_params.get("dump_dir", "").strip() or "/workspace"
+        snapshot_path, snapshot_err = _dump_memory_snapshot(out_dir=out_dir)
+        if snapshot_path:
+            info["snapshot_path"] = snapshot_path
+            info["snapshot_note"] = "Open at https://pytorch.org/memory_viz or: python -m torch.cuda._memory_viz trace_plot <path> -o out.html"
+        else:
+            info["snapshot_error"] = snapshot_err or "Set FISH_RECORD_MEMORY_HISTORY=1 at startup for alloc history in snapshot."
+    if request.query_params.get("format", "").strip().lower() == "text":
+        return Response(_gpu_memory_text(info), media_type="text/plain; charset=utf-8")
+    return JSONResponse(info)
 
 
 @routes.http.post("/v1/vqgan/encode")
@@ -161,7 +280,18 @@ async def tts(req: Annotated[ServeTTSRequest, Body(exclusive=True)]):
                 content_type=get_content_type(req.format),
             )
         else:
-            fake_audios = next(inference(req, engine))
+            chunks = []
+            for result in engine.inference(req):
+                if result.code == "error" and result.error:
+                    raise RuntimeError(str(result.error))
+                if result.code in ("segment", "final") and isinstance(result.audio, tuple):
+                    chunks.append(result.audio[1])
+            if not chunks:
+                raise HTTPException(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    content="No audio generated, please check the input text.",
+                )
+            fake_audios = np.concatenate(chunks, axis=0)
             buffer = io.BytesIO()
             sf.write(
                 buffer,
@@ -264,8 +394,66 @@ async def add_reference(
                 os.unlink(temp_file_path)
             except OSError as e:
                 logger.warning(
-                    f"Failed to clean up temporary file {temp_file_path}: {e}"
+                    "Failed to clean up temporary file %s: %s", temp_file_path, e
                 )
+
+
+@routes.http.post("/v1/references/add_encoded")
+async def add_reference_encoded(
+    id: str = Body(...),
+    codes: UploadFile = Body(...),
+    lab: UploadFile = Body(...),
+    stem: str | None = Body(None),
+):
+    """
+    Add or update a pre-encoded reference (.codes.pt + .lab). Skips write if content hash matches.
+    Optional stem: file names under references/<id>/ (default id). Use for multi-stem references.
+    """
+    try:
+        if not id or not id.strip():
+            raise ValueError("Reference ID cannot be empty")
+        codes_bytes = await codes.read()
+        lab_bytes = await lab.read()
+        if not codes_bytes:
+            raise ValueError("Codes file is empty")
+        lab_text = lab_bytes.decode("utf-8", errors="replace").strip()
+        if not lab_text:
+            raise ValueError("Lab content is empty")
+        stem_val = stem.strip() if stem and stem.strip() else None
+
+        app_state = request.app.state
+        model_manager: ModelManager = app_state.model_manager
+        engine = model_manager.tts_inference_engine
+
+        status = engine.add_reference_encoded(id, codes_bytes, lab_text, stem=stem_val)
+
+        response = AddEncodedReferenceResponse(
+            success=True,
+            status=status,
+            message=f"Reference '{id}' {status}",
+            reference_id=id,
+        )
+        return format_response(response)
+
+    except ValueError as e:
+        logger.warning("add_encoded invalid input: %s", e)
+        return format_response(
+            AddEncodedReferenceResponse(
+                success=False, status="error", message=str(e), reference_id=id or ""
+            ),
+            status_code=400,
+        )
+    except Exception as e:
+        logger.error("add_encoded error: %s", e, exc_info=True)
+        return format_response(
+            AddEncodedReferenceResponse(
+                success=False,
+                status="error",
+                message="Internal server error",
+                reference_id=id,
+            ),
+            status_code=500,
+        )
 
 
 @routes.http.get("/v1/references/list")

--- a/uv.lock
+++ b/uv.lock
@@ -1121,6 +1121,9 @@ cu129 = [
     { name = "torchaudio", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-11-fish-speech-cu129') or (platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129')" },
     { name = "torchaudio", version = "2.8.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra != 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra != 'extra-11-fish-speech-cpu' and extra != 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
 ]
+dev = [
+    { name = "pytest" },
+]
 stable = [
     { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-11-fish-speech-cpu') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
     { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (extra != 'extra-11-fish-speech-cpu' and extra != 'extra-11-fish-speech-cu126' and extra != 'extra-11-fish-speech-cu128' and extra != 'extra-11-fish-speech-cu129')" },
@@ -1135,6 +1138,11 @@ stable = [
     { name = "torchaudio", version = "2.8.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-11-fish-speech-cu126' or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
     { name = "torchaudio", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-11-fish-speech-cu128' or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cpu' and extra != 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
     { name = "torchaudio", version = "2.8.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra != 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra != 'extra-11-fish-speech-cpu' and extra != 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -1162,6 +1170,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.9.2" },
     { name = "pydub" },
     { name = "pyrootutils", specifier = ">=1.0.4" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "resampy", specifier = ">=0.4.3" },
     { name = "rich", specifier = ">=13.5.3" },
     { name = "safetensors" },
@@ -1185,7 +1194,10 @@ requires-dist = [
     { name = "wandb", specifier = ">=0.15.11" },
     { name = "zstandard", specifier = ">=0.22.0" },
 ]
-provides-extras = ["stable", "cpu", "cu126", "cu128", "cu129"]
+provides-extras = ["stable", "cpu", "cu126", "cu128", "cu129", "dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "flatbuffers"
@@ -1653,6 +1665,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -3553,6 +3574,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pooch"
 version = "1.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3931,6 +3961,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/3d/1ae8bdb686c6aaaeef474aa6b790abbe38f42b61188b57a974dd9320e521/pystoi-0.4.1.tar.gz", hash = "sha256:1c6f50d6fbfee46b00c922458cdbd27228d9830ca81cea788fd600fc2f7de6e4", size = 10401, upload-time = "2023-12-29T16:48:05.726Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/22/60cd92bd3ec00948800984410f4cf5ded5bd8e9b715729f3642efe0edb3d/pystoi-0.4.1-py2.py3-none-any.whl", hash = "sha256:e277b671663d26d35a2416c9c8010a74084e6c3970354506398051a554896939", size = 8218, upload-time = "2023-12-29T16:48:03.748Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
@@ -4782,6 +4830,60 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5128,16 +5230,16 @@ dependencies = [
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-11-fish-speech-cpu') or (platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (sys_platform != 'linux' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (sys_platform != 'linux' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (sys_platform != 'linux' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (extra != 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra != 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra != 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c2f44cf279f673cfcdd8f576c349eee8bedf8caab351a5dd78b32970cc34a212" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d3c1b85b26a09832d139f6d6da6b66caeb51d2e16e08f8587665c44a9e1aa8f9" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c9276857d241c6de257af765c0f51fc011af38cb725401495121b280913007cf" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4573c6042950c20278e3608a9a38050ba0bc72e0049e1bbfd249caf859a8029b" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ddef94bf181e6447cbb05f38beaca8f6c5bb8d2b9ddced1aa3452025b9fc70d3" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:862e2e40bf09d865e5df080a84c1a39bbcef40e43140f4b1737eb3a389d3b38f" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f851d32e94ca05e470f0c60e25726ec1e0eb71cb2ca5a0206b7fd03272ccc3c8" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:09535a9b727c0793cd07c1ace99f3f353626281bcc3e30c2f2314e3ebc9d3f96" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:68df9c9068984edff8065c2b6656725e6114fe89281b0cf122c7505305fc98a4" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1951f10ed092f2dda57634f6a3950ef21c9d9352551aa84a9fccd51bbda18095" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c2f44cf279f673cfcdd8f576c349eee8bedf8caab351a5dd78b32970cc34a212" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d3c1b85b26a09832d139f6d6da6b66caeb51d2e16e08f8587665c44a9e1aa8f9" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c9276857d241c6de257af765c0f51fc011af38cb725401495121b280913007cf" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4573c6042950c20278e3608a9a38050ba0bc72e0049e1bbfd249caf859a8029b" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ddef94bf181e6447cbb05f38beaca8f6c5bb8d2b9ddced1aa3452025b9fc70d3" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:862e2e40bf09d865e5df080a84c1a39bbcef40e43140f4b1737eb3a389d3b38f" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f851d32e94ca05e470f0c60e25726ec1e0eb71cb2ca5a0206b7fd03272ccc3c8" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:09535a9b727c0793cd07c1ace99f3f353626281bcc3e30c2f2314e3ebc9d3f96" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:68df9c9068984edff8065c2b6656725e6114fe89281b0cf122c7505305fc98a4" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1951f10ed092f2dda57634f6a3950ef21c9d9352551aa84a9fccd51bbda18095" },
 ]
 
 [[package]]
@@ -5154,11 +5256,11 @@ dependencies = [
     { name = "torch", version = "2.8.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-11-fish-speech-cu129') or (platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:731b33fcce4b31a5a6fd145c4d95d1e96ec437b39dcb74248c15432c93ac98a1" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:019fce8acccf36715b849eafd1b65c0ee5fd66fb5143a32dbbb883ee2ba204b3" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:67d4f6cbfcb795157850db6a3735301b929cdfe2b56032dc3365105b49a4ee84" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2086c64c321d949e9c3abcdf4da6405f1f5317c34980612cb1d9978bae7d7b6e" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fea5c90031ec7de069fa80228d8210d29595cc18c00f5e9954274f4e3f157e07" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:731b33fcce4b31a5a6fd145c4d95d1e96ec437b39dcb74248c15432c93ac98a1" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:019fce8acccf36715b849eafd1b65c0ee5fd66fb5143a32dbbb883ee2ba204b3" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:67d4f6cbfcb795157850db6a3735301b929cdfe2b56032dc3365105b49a4ee84" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2086c64c321d949e9c3abcdf4da6405f1f5317c34980612cb1d9978bae7d7b6e" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fea5c90031ec7de069fa80228d8210d29595cc18c00f5e9954274f4e3f157e07" },
 ]
 
 [[package]]
@@ -5219,16 +5321,16 @@ dependencies = [
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-11-fish-speech-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-11-fish-speech-cpu') or (sys_platform == 'darwin' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (sys_platform == 'darwin' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (sys_platform == 'darwin' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (sys_platform == 'darwin' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (sys_platform == 'darwin' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (sys_platform == 'darwin' and extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (sys_platform == 'linux' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (sys_platform == 'linux' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (sys_platform == 'linux' and extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra != 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra != 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra != 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c955835e470ebbde03d7d54ca5d8ba5722138bbfd66cfb86845234b3a5b9f9fa" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:e9e68f16f1afe108f0cb1c7d636d0242fdc43cbbcaab222a72a373b9d2799134" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e54bd7fc9472019308097d99102df9acee22aa2451ae808d27840bc874320292" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:db37df7eee906f8fe0a639fdc673f3541cb2e173169b16d4133447eb922d1938" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9377faee65a290578280ac7f4884c3586253dac2ca28c60f458ff6efe86a6b05" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:9b302192b570657c1cc787a4d487ae4bbb7f2aab1c01b1fcc46757e7f86f391e" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e1b1f530e8b71b1d079e23db45a0e621709061710ef8540aae8280aa039554ee" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:0c2d081e24204768e636cbf05e1377c8a6964b8ed6fa3aa5092ba9af9bbc19c5" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:89c2d04fe1cb7c31eb042f7b36e1ce8e2afacf769ecd5f216527e184e4857099" },
-    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:ab4653da31dc37f0a643f41f4da8bee647a8686bacf12d3929cac8aead186811" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c955835e470ebbde03d7d54ca5d8ba5722138bbfd66cfb86845234b3a5b9f9fa" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:e9e68f16f1afe108f0cb1c7d636d0242fdc43cbbcaab222a72a373b9d2799134" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e54bd7fc9472019308097d99102df9acee22aa2451ae808d27840bc874320292" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:db37df7eee906f8fe0a639fdc673f3541cb2e173169b16d4133447eb922d1938" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9377faee65a290578280ac7f4884c3586253dac2ca28c60f458ff6efe86a6b05" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:9b302192b570657c1cc787a4d487ae4bbb7f2aab1c01b1fcc46757e7f86f391e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e1b1f530e8b71b1d079e23db45a0e621709061710ef8540aae8280aa039554ee" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:0c2d081e24204768e636cbf05e1377c8a6964b8ed6fa3aa5092ba9af9bbc19c5" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:89c2d04fe1cb7c31eb042f7b36e1ce8e2afacf769ecd5f216527e184e4857099" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:ab4653da31dc37f0a643f41f4da8bee647a8686bacf12d3929cac8aead186811" },
 ]
 
 [[package]]
@@ -5249,16 +5351,16 @@ dependencies = [
     { name = "torch", version = "2.8.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" }, marker = "extra == 'extra-11-fish-speech-cu126' or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:dcec92ca53fd7ec1cf0257f15b127542f0d49855d5580578b14337fcc015f8af" },
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp310-cp310-win_amd64.whl", hash = "sha256:6fc06bb1d5b3be2061eafe03cff9d9040e51d900097b2f779844ae319c0f0cc3" },
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:77859ec6c6a92ca3b666a3f02363a5631e9676c027fb4dce99a461a089c9962c" },
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:48e19338f6fd24588cd5608b21087d00b80e30ddf054d9ce83f792a4b0025d7f" },
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:29d91c915d877dfe4714082d188b7677e059dfd57d43a2d4ad33641a7ef53feb" },
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp312-cp312-win_amd64.whl", hash = "sha256:4098eadd03a8d283b229677d1e02114fcf6a8bc331941a08232499e43ae8a497" },
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3a7d774faf904ee38c0d70b850db3e9a5847ba10df23b758378ad715108f1ed2" },
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp313-cp313-win_amd64.whl", hash = "sha256:a9ffc8eda507cfc94b072e084d3a8120ef237cdce3ce210856f56339e1c2e7b0" },
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8eaf7a52b1e20b6a72d0eea93be9c0489c72dd3ba7eaed91c9b06014632b3563" },
-    { url = "https://download.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp313-cp313t-win_amd64.whl", hash = "sha256:1f4be61af5f0ee8d3bf00d61e67251fef4c4bca36361cacc7a5e4af7d2339ce6" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:dcec92ca53fd7ec1cf0257f15b127542f0d49855d5580578b14337fcc015f8af" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp310-cp310-win_amd64.whl", hash = "sha256:6fc06bb1d5b3be2061eafe03cff9d9040e51d900097b2f779844ae319c0f0cc3" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:77859ec6c6a92ca3b666a3f02363a5631e9676c027fb4dce99a461a089c9962c" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:48e19338f6fd24588cd5608b21087d00b80e30ddf054d9ce83f792a4b0025d7f" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:29d91c915d877dfe4714082d188b7677e059dfd57d43a2d4ad33641a7ef53feb" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp312-cp312-win_amd64.whl", hash = "sha256:4098eadd03a8d283b229677d1e02114fcf6a8bc331941a08232499e43ae8a497" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3a7d774faf904ee38c0d70b850db3e9a5847ba10df23b758378ad715108f1ed2" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp313-cp313-win_amd64.whl", hash = "sha256:a9ffc8eda507cfc94b072e084d3a8120ef237cdce3ce210856f56339e1c2e7b0" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8eaf7a52b1e20b6a72d0eea93be9c0489c72dd3ba7eaed91c9b06014632b3563" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.8.0%2Bcu126-cp313-cp313t-win_amd64.whl", hash = "sha256:1f4be61af5f0ee8d3bf00d61e67251fef4c4bca36361cacc7a5e4af7d2339ce6" },
 ]
 
 [[package]]
@@ -5279,16 +5381,16 @@ dependencies = [
     { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-11-fish-speech-cu128' or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cpu' and extra != 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a0161e95285a0b716de210fee0392151d601e7da3cc86595008d826abff48a8c" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:5d7a9d913e2744573ed3b7ec2f781ed39833c81c9c41859973ec10ac174c2366" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f4409df567d0723a7a3a89d32c7552a17e0ff6f137ea26a0d268c665259b2995" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:7a1eb6154e05b8056b34c7a41495e09d57f79eb0180eb4e7f3bb2a61845ca8ea" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:145b8a0c21cfcaa1705c67173c5d439087e0e120d5da9bc344746f937901d243" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:cce3a60cd9a97f7360c8f95504ac349311fb7d6b9b826135936764f4de5f782d" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:410bb8ea46225efe658e5d27a3802c181a2255913003621a5d25a51aca8018d9" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:3146bbd48992d215f6bb1aef9626d734c3180b377791ded2a4d4d2c0e63c0cc2" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:04b410f93337fc6c16576d0c88e2a31091aef9d1fd212ebb8cd26899dba175e0" },
-    { url = "https://download.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:1054e0a7613cac54ed9b3784a5fcbe023748a70004d9cca74c5f9ae00a1fdfd1" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a0161e95285a0b716de210fee0392151d601e7da3cc86595008d826abff48a8c" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:5d7a9d913e2744573ed3b7ec2f781ed39833c81c9c41859973ec10ac174c2366" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f4409df567d0723a7a3a89d32c7552a17e0ff6f137ea26a0d268c665259b2995" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:7a1eb6154e05b8056b34c7a41495e09d57f79eb0180eb4e7f3bb2a61845ca8ea" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:145b8a0c21cfcaa1705c67173c5d439087e0e120d5da9bc344746f937901d243" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:cce3a60cd9a97f7360c8f95504ac349311fb7d6b9b826135936764f4de5f782d" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:410bb8ea46225efe658e5d27a3802c181a2255913003621a5d25a51aca8018d9" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:3146bbd48992d215f6bb1aef9626d734c3180b377791ded2a4d4d2c0e63c0cc2" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:04b410f93337fc6c16576d0c88e2a31091aef9d1fd212ebb8cd26899dba175e0" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:1054e0a7613cac54ed9b3784a5fcbe023748a70004d9cca74c5f9ae00a1fdfd1" },
 ]
 
 [[package]]
@@ -5309,16 +5411,16 @@ dependencies = [
     { name = "torch", version = "2.8.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(platform_machine != 'aarch64' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra != 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129') or (sys_platform != 'linux' and extra != 'extra-11-fish-speech-cpu' and extra != 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu126') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cpu' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu128') or (extra == 'extra-11-fish-speech-cu126' and extra == 'extra-11-fish-speech-cu129') or (extra == 'extra-11-fish-speech-cu128' and extra == 'extra-11-fish-speech-cu129')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:bf779145a53e2ea8eddb1ba9802fc4723ea1b927c98951a3430794061cf779d5" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp310-cp310-win_amd64.whl", hash = "sha256:a477f1320197311608fbc8ced0484c897cb285b38d583f2080cddf373194fe82" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:6115c725e6c21548aed6a2c78a2233e7fce1d249ec9997f1ba062c86d99f4003" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp311-cp311-win_amd64.whl", hash = "sha256:964e442feb548bb373e3fe9fae64a8cc3e413e4855bbd82aa9e8897966f700ae" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:40df9011972519120f284f56e5e7d131d4250ea69653499028d1d30b353f932e" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp312-cp312-win_amd64.whl", hash = "sha256:bfe0d4c6e770ef3b1f7a287a4c8d33ac276a1d983306573ee28e42de02a32fe3" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:475546c447c9dfab88caa10334502576e0ba5f46742e5e67ddd09094affa8d48" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp313-cp313-win_amd64.whl", hash = "sha256:42b462e8de400421c693ddbd3c88fde5fbe2c2474c3e4a709db99d635c512e79" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:d7a234d0ad889c7d2986de6f759bb6d6550873bfcbbfe29529a85240d263a78b" },
-    { url = "https://download.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp313-cp313t-win_amd64.whl", hash = "sha256:88a216cb4538eddb488fee7bcbb1b4028cc6a3fe47b96dd67af073cf67562037" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:bf779145a53e2ea8eddb1ba9802fc4723ea1b927c98951a3430794061cf779d5" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp310-cp310-win_amd64.whl", hash = "sha256:a477f1320197311608fbc8ced0484c897cb285b38d583f2080cddf373194fe82" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:6115c725e6c21548aed6a2c78a2233e7fce1d249ec9997f1ba062c86d99f4003" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp311-cp311-win_amd64.whl", hash = "sha256:964e442feb548bb373e3fe9fae64a8cc3e413e4855bbd82aa9e8897966f700ae" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:40df9011972519120f284f56e5e7d131d4250ea69653499028d1d30b353f932e" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp312-cp312-win_amd64.whl", hash = "sha256:bfe0d4c6e770ef3b1f7a287a4c8d33ac276a1d983306573ee28e42de02a32fe3" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:475546c447c9dfab88caa10334502576e0ba5f46742e5e67ddd09094affa8d48" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp313-cp313-win_amd64.whl", hash = "sha256:42b462e8de400421c693ddbd3c88fde5fbe2c2474c3e4a709db99d635c512e79" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:d7a234d0ad889c7d2986de6f759bb6d6550873bfcbbfe29529a85240d263a78b" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.8.0%2Bcu129-cp313-cp313t-win_amd64.whl", hash = "sha256:88a216cb4538eddb488fee7bcbb1b4028cc6a3fe47b96dd67af073cf67562037" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Streaming works** on this branch — low TTFA (~400ms with `torch.compile` flag), chunks as they're ready. Docker + scripts for ~32GB GPUs (e.g. RTX 5090), so anyone can try it. **Draft, don't merge** :rofl:

**Branch:** [konovalov-nk/fish-speech@feature/32gb-docker-e2e](https://github.com/konovalov-nk/fish-speech/tree/feature/32gb-docker-e2e)
**Docs:** `docs/docker-32gb-rtx5090.md`

**Minimal run:** From repo root: `make run-server` (start API in Docker), then `make e2e` (smoke test). `make help` for all targets.

- `scripts/run_server_32gb.sh`, `WORKSPACE_DIR` for nested repo
- KV cache / memory: `clear_caches()`, `FISH_CACHE_MAX_SEQ_LEN`, `/v1/debug/memory`
- E2E: `scripts/e2e_smoke.sh`, `e2e_memory.sh`; uses `reference_id` from server when available
- References: preencode, `upload_references.sh`, `POST /v1/references/add_encoded` (skip if hash matches)
- Makefile: run-server, e2e, preencode, upload-references, test

**What's left to do:**
1. Stream tokens into vocoder with a schedule (per lengyue), not one big chunk.
2. Cut memory use more and improve TTFA (profile, smaller first chunk, CUDA graphs).
3. Support longer prompts (~30–50 words) for agent TTS without OOM.