### PR TITLE
fix: guard output layer in setup_lora for weight-tied models

### DIFF
--- a/fish_speech/models/text2semantic/lora.py
+++ b/fish_speech/models/text2semantic/lora.py
@@ -29,8 +29,10 @@ def setup_lora(model, lora_config):
         model.codebook_embeddings, lora_config
     )
 
-    # Replace output layer with a LoRA layer
-    linears = [(model, "output")]
+    # Replace output layer with a LoRA layer (only exists when tie_word_embeddings=False)
+    linears = []
+    if hasattr(model, "output"):
+        linears.append((model, "output"))
 
     # Replace all linear layers with LoRA layers
     for layer in model.layers:


### PR DESCRIPTION
Fixes #1195

### Problem

`setup_lora()` unconditionally adds `(model, "output")` to the replacement list, but `BaseTransformer` only creates `self.output` when `tie_word_embeddings` is `False`. Since the default is `True`, running LoRA fine-tuning with the documented command crashes with `AttributeError`.

### Change

Added a `hasattr(model, "output")` check before appending, matching the existing `hasattr(model, "fast_layers")` pattern on line 48 of the same file.

```diff
-    # Replace output layer with a LoRA layer
-    linears = [(model, "output")]
+    # Replace output layer with a LoRA layer (only exists when tie_word_embeddings=False)
+    linears = []
+    if hasattr(model, "output"):
+        linears.append((model, "output"))
```

### Verification

- `tie_word_embeddings=True` (default): `setup_lora()` skips `output` and completes normally
- `tie_word_embeddings=False`: `output` is included as before — no behavior change