### PR TITLE
fix: check if output layer exists before adding to LoRA layers

### DIFF
--- a/fish_speech/models/text2semantic/lora.py
+++ b/fish_speech/models/text2semantic/lora.py
@@ -29,8 +29,10 @@ def setup_lora(model, lora_config):
         model.codebook_embeddings, lora_config
     )
 
-    # Replace output layer with a LoRA layer
-    linears = [(model, "output")]
+    # Replace output layer with a LoRA layer (only if it exists, i.e., when tie_word_embeddings=False)
+    linears = []
+    if hasattr(model, "output"):
+        linears.append((model, "output"))
 
     # Replace all linear layers with LoRA layers
     for layer in model.layers:


### PR DESCRIPTION
## Description

When `tie_word_embeddings=True` (the default), the model doesn't have an `output` attribute since it uses weight tying instead of a separate output projection. This caused an `AttributeError` when running LoRA fine-tuning with the default config.

## Fix

This fix adds a `hasattr` check before adding the output layer to the linears list, consistent with the pattern used elsewhere in the codebase (e.g., `fast_layers` check on line 42).

## Testing

The fix follows the same pattern used in `llama.py` where `tie_word_embeddings` is already checked in both `forward()` and `forward_generate()` methods.

## Related

Fixes #1195