### PR TITLE
fix: add missing f-string prefix in TypeError message

### DIFF
--- a/fish_speech/inference_engine/__init__.py
+++ b/fish_speech/inference_engine/__init__.py
@@ -101,7 +101,7 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             # Check the response type
             if not isinstance(wrapped_result.response, GenerateResponse):
                 raise TypeError(
-                    "Expected GenerateResponse, got {type(wrapped_result.response).__name__}"
+                    f"Expected GenerateResponse, got {type(wrapped_result.response).__name__}"
                 )
 
             result: GenerateResponse = wrapped_result.response


### PR DESCRIPTION
### Is this PR adding new feature or fix a BUG?

Fix BUG.

### Is this pull request related to any issue? If yes, please link the issue.

No related issue.

### Description

The TypeError message in TTSInferenceEngine.inference() (fish_speech/inference_engine/__init__.py:103) is missing the f prefix, causing the format expression {type(wrapped_result.response).__name__} to appear literally instead of being interpolated.

**Before:** "Expected GenerateResponse, got {type(wrapped_result.response).__name__}" 
**After:** f"Expected GenerateResponse, got {type(wrapped_result.response).__name__}"