### PR TITLE
fix: correct wants_json to accept "application/json" format parameter

### DIFF
--- a/tools/server/api_utils.py
+++ b/tools/server/api_utils.py
@@ -106,7 +106,7 @@ def wants_json(req):
     """
     q = req.query_params.get("format", "").strip().lower()
     if q in {"json", "application/json", "msgpack", "application/msgpack"}:
-        return q == "json"
+        return q in ("json", "application/json")
     accept = req.headers.get("Accept", "").strip().lower()
     return "application/json" in accept and "application/msgpack" not in accept
 


### PR DESCRIPTION
### Is this PR adding new feature or fix a BUG?

Fix BUG.

### Is this pull request related to any issue? If yes, please link the issue.

No related issue.

### Description

In tools/server/api_utils.py, the wants_json() function checks q == "json" to determine the response format. When a client passes ?format=application/json, this evaluates to False, causing the server to return msgpack instead of the requested JSON format.

Fix: changed return q == "json" to return q in ("json", "application/json").