### PR TITLE
fix: preserve original error message in webui error display

### DIFF
--- a/tools/webui/inference.py
+++ b/tools/webui/inference.py
@@ -68,12 +68,12 @@ def get_reference_audio(reference_audio: str, reference_text: str) -> list:
 
 def build_html_error_message(error: Any) -> str:
 
-    error = error if isinstance(error, Exception) else Exception("Unknown error")
+    error_str = str(error) if error is not None else "Unknown error"
 
     return f"""
     <div style="color: red; 
     font-weight: bold;">
-        {html.escape(str(error))}
+        {html.escape(error_str)}
     </div>
     """
 


### PR DESCRIPTION
### Is this PR adding new feature or fix a BUG?

Fix BUG.

### Is this pull request related to any issue? If yes, please link the issue.

No related issue.

### Description

In tools/webui/inference.py, build_html_error_message() wraps non-Exception values with Exception("Unknown error"), discarding the actual error content. When the inference engine returns string error messages (e.g. via i18n(result.error)), users see "Unknown error" instead of the real message.

Fix: convert the error to string directly via str(error) instead of wrapping it in a new Exception.