### PR TITLE
fix: initialize diff_l1 before validation loop in merge_lora

### DIFF
--- a/tools/llama/merge_lora.py
+++ b/tools/llama/merge_lora.py
@@ -78,6 +78,7 @@ def merge(lora_config, base_weight, lora_weight, output):
     original_keys = set(llama_state_dict_copy.keys())
 
     tolerance = 1e-5
+    diff_l1 = 0.0
     for key in original_keys:
         diff_l1 = (new_state_dict[key] - llama_state_dict_copy[key]).abs().sum().item()
         if diff_l1 > tolerance:


### PR DESCRIPTION
### Is this PR adding new feature or fix a BUG?

Fix BUG.

### Is this pull request related to any issue? If yes, please link the issue.

No related issue.

### Description

In tools/llama/merge_lora.py, the variable diff_l1 is only assigned inside the for key in original_keys: loop. When original_keys is empty (e.g. if the base model state_dict was processed differently), the loop body never executes and the subsequent if diff_l1 <= tolerance: raises NameError: name 'diff_l1' is not defined.

Fix: initialize diff_l1 = 0.0 before the loop.