### PR TITLE
fix: remove references to nonexistent keys in vqgan dataset test

### DIFF
--- a/fish_speech/datasets/vqgan.py
+++ b/fish_speech/datasets/vqgan.py
@@ -141,7 +141,5 @@ if __name__ == "__main__":
 
     for batch in dataloader:
         print(batch["audios"].shape)
-        print(batch["features"].shape)
         print(batch["audio_lengths"])
-        print(batch["feature_lengths"])
         break


### PR DESCRIPTION
### Is this PR adding new feature or fix a BUG?

Fix BUG.

### Is this pull request related to any issue? If yes, please link the issue.

No related issue.

### Description

The __main__ test block in fish_speech/datasets/vqgan.py accesses batch["features"] and batch["feature_lengths"], but VQGANCollator.__call__() only returns keys "audios" and "audio_lengths". Running python -m fish_speech.datasets.vqgan raises KeyError.

Fix: removed the two lines referencing nonexistent keys.