### PR TITLE
fix: add reference ID validation to prevent path traversal

### DIFF
--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -17,7 +17,6 @@ from fish_speech.utils.file import (
 )
 from fish_speech.utils.schema import ServeReferenceAudio
 
-
 _ID_PATTERN = re.compile(r"^[a-zA-Z0-9\-_ ]+$")
 
 

--- a/tools/server/views.py
+++ b/tools/server/views.py
@@ -309,9 +309,7 @@ async def delete_reference(reference_id: str = Body(...)):
 
         id_pattern = r"^[a-zA-Z0-9\-_ ]+$"
         if not re.match(id_pattern, reference_id) or len(reference_id) > 255:
-            raise ValueError(
-                "Reference ID contains invalid characters or is too long"
-            )
+            raise ValueError("Reference ID contains invalid characters or is too long")
 
         # Get the model manager to access the reference loader
         app_state = request.app.state


### PR DESCRIPTION
### Is this PR adding new feature or fix a BUG?

Fix BUG.

### Is this pull request related to any issue? If yes, please link the issue.

No related issue.

### Description

The add_reference method in ReferenceLoader validates reference IDs against a safe pattern (^[a-zA-Z0-9\-_ ]+$), but load_by_id, delete_reference, and the corresponding API endpoints (/v1/references/delete, /v1/references/update) do not perform this validation. An attacker could pass an ID containing ../ to traverse outside the references/ directory, potentially reading, creating, or deleting arbitrary directories.

### Changes:

- Extracted the ID validation into a reusable _validate_id() static method
- Applied validation to load_by_id and delete_reference in ReferenceLoader
- Added validation for reference_id in the delete endpoint
- Added validation for old_reference_id in the update endpoint (was only validated for new_reference_id)