### PR TITLE
fix(lora): skip output layer when tie_word_embeddings=True

### DIFF
--- a/fish_speech/models/text2semantic/lora.py
+++ b/fish_speech/models/text2semantic/lora.py
@@ -29,8 +29,11 @@ def setup_lora(model, lora_config):
         model.codebook_embeddings, lora_config
     )
 
-    # Replace output layer with a LoRA layer
-    linears = [(model, "output")]
+    # Replace output layer with a LoRA layer (only if model has output attribute)
+    # When tie_word_embeddings=True (default), the model uses weight tying instead
+    linears = []
+    if hasattr(model, "output"):
+        linears.append((model, "output"))
 
     # Replace all linear layers with LoRA layers
     for layer in model.layers:


### PR DESCRIPTION
## Description

When `tie_word_embeddings=True` (the default, line 42 in llama.py), the model uses weight tying and does not have an "output" attribute. This caused an `AttributeError` when running LoRA fine-tuning with default config.

## Fix

Add `hasattr(model, "output")` check before adding the output layer to the linears list, similar to the existing `fast_layers` check.

Closes #1195