### PR TITLE
fix:AttributeError during LoRA training

### DIFF
--- a/fish_speech/models/text2semantic/lora.py
+++ b/fish_speech/models/text2semantic/lora.py
@@ -29,8 +29,10 @@ def setup_lora(model, lora_config):
         model.codebook_embeddings, lora_config
     )
 
-    # Replace output layer with a LoRA layer
-    linears = [(model, "output")]
+    # Replace output layer with a LoRA layer (only if it exists)
+    linears = []
+    if hasattr(model, "output"):
+        linears.append((model, "output"))
 
     # Replace all linear layers with LoRA layers
     for layer in model.layers:
@@ -47,7 +49,8 @@ def setup_lora(model, lora_config):
         model.fast_embeddings = _replace_embedding(model.fast_embeddings, lora_config)
 
         # Dual-AR model
-        linears.append((model, "fast_output"))
+        if hasattr(model, "fast_output"):
+            linears.append((model, "fast_output"))
 
         for layer in model.fast_layers:
             linears.extend([(layer.attention, "wqkv"), (layer.attention, "wo")])


### PR DESCRIPTION
修复了LoRA训练时的AttributeError错误。
问题的根本原因是：在setup_lora函数中，代码假设所有模型有'output'和'fast_output'属性，但对于DualARTransformer模型，当tie_word_embeddings=True时，这些属性不会被创建。
在setup_lora函数中添加了属性存在性检查：
只有在模型确实有'output'属性时才尝试替换它
只有在模型确实有'fast_output'属性时才尝试替换它
Fixed the AttributeError that occurred during LoRA training.
The root cause of the issue was that, in the `setup_lora` function, the code assumed that all models have ‘output’ and ‘fast_output’ attributes; however, for the DualARTransformer model, these attributes are not created when `tie_word_embeddings=True`.
Added property existence checks to the `setup_lora` function:
Only attempt to replace the `output` property if the model actually has it.
Only attempt to replace the `fast_output` property if the model actually has it.