### PR TITLE
fix(docker): bump CUDA 12.6 → 12.9 for Blackwell (sm_120) support

### DIFF
--- a/compose.base.yml
+++ b/compose.base.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: docker/Dockerfile
       args:
         BACKEND: ${BACKEND:-cuda}     # or cpu
+        CUDA_VER: ${CUDA_VER:-12.9.0}
+        UV_EXTRA: ${UV_EXTRA:-cu129}
         UV_VERSION: ${UV_VERSION:-0.8.15}
     volumes:
       - ./checkpoints:/app/checkpoints

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,9 +61,9 @@
 
 
 # Select the specific cuda version (see https://hub.docker.com/r/nvidia/cuda/)
-ARG CUDA_VER=12.6.0
+ARG CUDA_VER=12.9.0
 # Adapt the uv extra to fit the cuda version (one of [cu126, cu128, cu129])
-ARG UV_EXTRA=cu126
+ARG UV_EXTRA=cu129
 ARG BACKEND=cuda
 
 ARG UBUNTU_VER=24.04

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -113,6 +113,8 @@ COMPILE=1                 # Enable compile optimization
 GRADIO_PORT=7860         # WebUI port
 API_PORT=8080            # API server port
 UV_VERSION=0.8.15        # UV package manager version
+CUDA_VER=12.9.0          # CUDA base image version (e.g. 12.6.0 for older drivers)
+UV_EXTRA=cu129           # PyTorch CUDA variant (cu126, cu128, cu129) — must match CUDA_VER
 ```
 
 The command will build the image and run the container. You can access the WebUI at `http://localhost:7860` and the API server at `http://localhost:8080`.
@@ -127,8 +129,8 @@ docker build \
     --platform linux/amd64 \
     -f docker/Dockerfile \
     --build-arg BACKEND=cuda \
-    --build-arg CUDA_VER=12.6.0 \
-    --build-arg UV_EXTRA=cu126 \
+    --build-arg CUDA_VER=12.9.0 \
+    --build-arg UV_EXTRA=cu129 \
     --target webui \
     -t fish-speech-webui:cuda .
 
@@ -137,8 +139,8 @@ docker build \
     --platform linux/amd64 \
     -f docker/Dockerfile \
     --build-arg BACKEND=cuda \
-    --build-arg CUDA_VER=12.6.0 \
-    --build-arg UV_EXTRA=cu126 \
+    --build-arg CUDA_VER=12.9.0 \
+    --build-arg UV_EXTRA=cu129 \
     --target server \
     -t fish-speech-server:cuda .
 


### PR DESCRIPTION
CUDA 12.6 / cu126 fails with "no kernel image available" on Blackwell GPUs (RTX 5000 series, sm_120). Upgrading to CUDA 12.9 / cu129 fixes this. CUDA_VER and UV_EXTRA are now exposed as overridable build args in compose.base.yml so users on older drivers can still pass CUDA_VER=12.6.0 UV_EXTRA=cu126 to restore the previous behaviour.

**Is this PR adding new feature or fix a BUG?**

Fix BUG.

**Is this pull request related to any issue? If yes, please link the issue.**

#1224 
