### PR TITLE
Fix UnboundLocalError for tokenizer in from_pretrained

### DIFF
--- a/fish_speech/models/text2semantic/llama.py
+++ b/fish_speech/models/text2semantic/llama.py
@@ -496,6 +496,7 @@ class BaseTransformer(nn.Module):
             config.rope_base = rope_base
             logger.info(f"Override rope_base to {rope_base}")
 
+        tokenizer = None
         try:
             tokenizer = FishTokenizer.from_pretrained(path)
             config.semantic_begin_id = tokenizer.semantic_begin_id


### PR DESCRIPTION
## Summary

Fix `UnboundLocalError` crash when `FishTokenizer.from_pretrained()` fails during model loading.

## Problem

When loading a model checkpoint where the tokenizer can't be instantiated (e.g., older checkpoints like `fish-speech-1.5` with newer code, or when `transformers` doesn't recognize the `dual_ar` model type), `from_pretrained()` crashes at line 523:

```
UnboundLocalError: cannot access local variable 'tokenizer' where it is not associated with a value
```

The `tokenizer` variable is only assigned inside the `try` block (line 500). If the `except` catches an error, `tokenizer` is never defined, but line 523 (`model.tokenizer = tokenizer`) still tries to access it.

## Fix

Initialize `tokenizer = None` before the `try` block. This allows the model to load successfully even when the tokenizer can't be instantiated — the warning is already logged, and `model.tokenizer` will be `None` instead of crashing.

## Reproduction

```bash
python tools/api_server.py \
  --llama-checkpoint-path checkpoints/fish-speech-1.5 \
  --decoder-checkpoint-path checkpoints/fish-speech-1.5/firefly-gan-vq-fsq-8x1024-21hz-generator.pth \
  --device cuda
```

Crashes without this fix. Works with it.

## Changes

- `fish_speech/models/text2semantic/llama.py`: Add `tokenizer = None` before `try` block (1 line)