### PR TITLE
feat(api): add reference_payload support for /v1/tts

### DIFF
--- a/docs/en/server.md
+++ b/docs/en/server.md
@@ -39,6 +39,70 @@ Expected response:
 - `POST /v1/tts` for text-to-speech generation
 - `POST /v1/vqgan/encode` for VQ encode
 - `POST /v1/vqgan/decode` for VQ decode
+- `GET /v1/references/compatibility` for the runtime prompt-bundle contract
+
+### Reusing a VQ-encoded prompt bundle
+
+For advanced integrations, a client can encode a reference audio once with `/v1/vqgan/encode`, fetch the runtime compatibility contract from `/v1/references/compatibility`, then send the resulting prompt bundle directly to `/v1/tts` as `reference_payload`.
+
+This is useful when your own backend wants to cache and replay prompt tokens without resending raw reference audio on every TTS request.
+
+Example flow:
+
+1. Call `POST /v1/vqgan/encode`
+2. Call `GET /v1/references/compatibility`
+3. Store a prompt bundle on your backend:
+
+```json
+{
+  "reference_id": "debug-sky",
+  "reference_text": "Hello there.",
+  "prompt_tokens": [[1, 2], [3, 4], [5, 6]],
+  "reference_fingerprint": "sha256:...",
+  "compatibility": {
+    "artifact_schema_version": 1,
+    "codec_checkpoint_sha256": "sha256:...",
+    "decoder_config_name": "modded_dac_vq",
+    "text2semantic_checkpoint_sha256": "sha256:...",
+    "tokenizer_sha256": "sha256:...",
+    "num_codebooks": 3,
+    "semantic_begin_id": 1024,
+    "sample_rate_hz": 24000
+  }
+}
+```
+
+4. Send that bundle to `POST /v1/tts`:
+
+```json
+{
+  "text": "Say hello",
+  "reference_payload": {
+    "reference_id": "debug-sky",
+    "reference_text": "Hello there.",
+    "prompt_tokens": [[1, 2], [3, 4], [5, 6]],
+    "reference_fingerprint": "sha256:...",
+    "compatibility": {
+      "artifact_schema_version": 1,
+      "codec_checkpoint_sha256": "sha256:...",
+      "decoder_config_name": "modded_dac_vq",
+      "text2semantic_checkpoint_sha256": "sha256:...",
+      "tokenizer_sha256": "sha256:...",
+      "num_codebooks": 3,
+      "semantic_begin_id": 1024,
+      "sample_rate_hz": 24000
+    }
+  }
+}
+```
+
+Request precedence is:
+
+- `reference_payload`
+- `references`
+- `reference_id`
+
+So if `reference_payload` is present, the server ignores inline `references` and `reference_id`.
 
 ### Python client example
 

--- a/fish_speech/inference_engine/__init__.py
+++ b/fish_speech/inference_engine/__init__.py
@@ -1,5 +1,7 @@
 import gc
 import queue
+import unicodedata
+from hashlib import sha256
 from typing import Generator
 
 import numpy as np
@@ -16,7 +18,34 @@ from fish_speech.models.text2semantic.inference import (
     WrappedGenerateResponse,
 )
 from fish_speech.utils import autocast_exclude_mps, set_seed
-from fish_speech.utils.schema import ServeTTSRequest
+from fish_speech.utils.schema import (
+    ServeReferenceCompatibility,
+    ServeReferencePayload,
+    ServeTTSRequest,
+)
+
+
+def _normalize_reference_text(text: str) -> str:
+    return unicodedata.normalize("NFC", text).replace("\r\n", "\n").strip()
+
+
+def _build_prompt_fingerprint(
+    reference_text: str,
+    prompt_tokens: list[list[int]],
+    artifact_schema_version: int = 1,
+) -> str:
+    normalized_text = _normalize_reference_text(reference_text)
+    token_tensor = torch.tensor(prompt_tokens, dtype=torch.int32)
+    shape_ascii = f"{token_tensor.shape[0]},{token_tensor.shape[1]}".encode("ascii")
+    preimage = (
+        f"v{artifact_schema_version}\n".encode("ascii")
+        + normalized_text.encode("utf-8")
+        + b"\nint32\n"
+        + shape_ascii
+        + b"\n"
+        + token_tensor.contiguous().numpy().tobytes()
+    )
+    return f"sha256:{sha256(preimage).hexdigest()}"
 
 
 class TTSInferenceEngine(ReferenceLoader, VQManager):
@@ -27,6 +56,7 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
         decoder_model: DAC,
         precision: torch.dtype,
         compile: bool,
+        reference_compatibility: ServeReferenceCompatibility | None = None,
     ) -> None:
 
         super().__init__()
@@ -35,6 +65,50 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
         self.decoder_model = decoder_model
         self.precision = precision
         self.compile = compile
+        if reference_compatibility is None:
+            sample_rate_hz = getattr(self.decoder_model, "sample_rate", 0)
+            quantizer = getattr(self.decoder_model, "quantizer", None)
+            num_codebooks = getattr(quantizer, "n_codebooks", 0) + 1
+            reference_compatibility = ServeReferenceCompatibility(
+                artifact_schema_version=1,
+                codec_checkpoint_sha256="sha256:unknown",
+                decoder_config_name=type(self.decoder_model).__name__,
+                text2semantic_checkpoint_sha256="sha256:unknown",
+                tokenizer_sha256="sha256:unknown",
+                num_codebooks=num_codebooks,
+                semantic_begin_id=0,
+                sample_rate_hz=sample_rate_hz,
+            )
+        self.reference_compatibility = reference_compatibility
+
+    def resolve_reference_payload(
+        self, reference_payload: ServeReferencePayload
+    ) -> tuple[list[torch.Tensor], list[str], str]:
+        expected = self.reference_compatibility.model_dump(mode="python")
+        actual = reference_payload.compatibility.model_dump(mode="python")
+        for field_name, expected_value in expected.items():
+            if actual.get(field_name) != expected_value:
+                raise ValueError(
+                    f"reference_payload compatibility mismatch for '{field_name}'"
+                )
+
+        reference_fingerprint = _build_prompt_fingerprint(
+            reference_payload.reference_text,
+            reference_payload.prompt_tokens,
+            artifact_schema_version=actual["artifact_schema_version"],
+        )
+        if (
+            reference_payload.reference_fingerprint is not None
+            and reference_payload.reference_fingerprint != reference_fingerprint
+        ):
+            raise ValueError("reference_payload fingerprint mismatch")
+
+        normalized_text = _normalize_reference_text(reference_payload.reference_text)
+        prompt_tokens = [
+            torch.tensor(reference_payload.prompt_tokens, dtype=torch.long)
+        ]
+        prompt_texts = [normalized_text]
+        return prompt_tokens, prompt_texts, reference_fingerprint
 
     @torch.inference_mode()
     def inference(self, req: ServeTTSRequest) -> Generator[InferenceResult, None, None]:
@@ -47,14 +121,29 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
 
         ref_id: str | None = req.reference_id
         prompt_tokens, prompt_texts = [], []
-        # Load the reference audio and text based on id or hash
-        if ref_id is not None:
-            prompt_tokens, prompt_texts = self.load_by_id(ref_id, req.use_memory_cache)
-
-        elif req.references:
+        reference_source = req.effective_reference_source()
+        if reference_source == "reference_payload":
+            if req.references:
+                logger.warning(
+                    "Ignoring inline references because reference_payload takes precedence"
+                )
+            if ref_id is not None:
+                logger.warning(
+                    "Ignoring reference_id because reference_payload takes precedence"
+                )
+            prompt_tokens, prompt_texts, _ = self.resolve_reference_payload(
+                req.reference_payload
+            )
+        elif reference_source == "references":
+            if ref_id is not None:
+                logger.warning(
+                    "Ignoring reference_id because inline references take precedence"
+                )
             prompt_tokens, prompt_texts = self.load_by_hash(
                 req.references, req.use_memory_cache
             )
+        elif ref_id is not None:
+            prompt_tokens, prompt_texts = self.load_by_id(ref_id, req.use_memory_cache)
 
         # Set the random seed if provided
         if req.seed is not None:

--- a/fish_speech/utils/schema.py
+++ b/fish_speech/utils/schema.py
@@ -2,7 +2,7 @@ import base64
 import os
 import queue
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 import torch
 from pydantic import BaseModel, Field, conint, model_validator
@@ -78,6 +78,53 @@ class ServeReferenceAudio(BaseModel):
         return f"ServeReferenceAudio(text={self.text!r}, audio_size={len(self.audio)})"
 
 
+class ServeReferenceCompatibility(BaseModel):
+    artifact_schema_version: Literal[1] = 1
+    codec_checkpoint_sha256: str
+    decoder_config_name: str
+    text2semantic_checkpoint_sha256: str
+    tokenizer_sha256: str
+    num_codebooks: Annotated[int, Field(gt=0, strict=True)]
+    semantic_begin_id: Annotated[int, Field(ge=0, strict=True)]
+    sample_rate_hz: Annotated[int, Field(gt=0, strict=True)]
+
+
+class ServeReferencePayload(BaseModel):
+    reference_id: str | None = None
+    reference_text: str
+    prompt_tokens: SkipValidation[list[list[int]]]
+    reference_fingerprint: str | None = None
+    compatibility: ServeReferenceCompatibility
+
+    @model_validator(mode="after")
+    def validate_payload(self):
+        if not self.reference_text.strip():
+            raise ValueError("reference_text cannot be empty")
+
+        if not self.prompt_tokens:
+            raise ValueError("prompt_tokens cannot be empty")
+
+        if len(self.prompt_tokens) != self.compatibility.num_codebooks:
+            raise ValueError(
+                "prompt_tokens row count must equal compatibility.num_codebooks"
+            )
+
+        row_lengths = {len(row) for row in self.prompt_tokens}
+        if 0 in row_lengths:
+            raise ValueError("prompt_tokens rows cannot be empty")
+        if len(row_lengths) != 1:
+            raise ValueError("all prompt_tokens rows must have the same length")
+
+        for row in self.prompt_tokens:
+            for token in row:
+                if not isinstance(token, int) or token < 0:
+                    raise ValueError(
+                        "prompt_tokens must contain only non-negative integers"
+                    )
+
+        return self
+
+
 class ServeTTSRequest(BaseModel):
     text: str
     chunk_length: Annotated[int, conint(ge=100, le=1000, strict=True)] = 200
@@ -91,6 +138,7 @@ class ServeTTSRequest(BaseModel):
     # For example, if you want use https://fish.audio/m/7f92f8afb8ec43bf81429cc1c9199cb1/
     # Just pass 7f92f8afb8ec43bf81429cc1c9199cb1
     reference_id: str | None = None
+    reference_payload: ServeReferencePayload | None = None
     seed: int | None = None
     use_memory_cache: Literal["on", "off"] = "off"
     # Normalize text for en & zh, this increase stability for numbers
@@ -101,6 +149,17 @@ class ServeTTSRequest(BaseModel):
     top_p: Annotated[float, Field(ge=0.1, le=1.0, strict=True)] = 0.8
     repetition_penalty: Annotated[float, Field(ge=0.9, le=2.0, strict=True)] = 1.1
     temperature: Annotated[float, Field(ge=0.1, le=1.0, strict=True)] = 0.8
+
+    def effective_reference_source(
+        self,
+    ) -> Literal["reference_payload", "references", "reference_id", "none"]:
+        if self.reference_payload is not None:
+            return "reference_payload"
+        if self.references:
+            return "references"
+        if self.reference_id is not None:
+            return "reference_id"
+        return "none"
 
     class Config:
         # Allow arbitrary types for pytorch related types
@@ -136,3 +195,9 @@ class UpdateReferenceResponse(BaseModel):
     message: str
     old_reference_id: str
     new_reference_id: str
+
+
+class ReferenceCompatibilityResponse(BaseModel):
+    success: bool
+    compatibility: ServeReferenceCompatibility
+    message: str = "Success"

--- a/tests/test_reference_compatibility_endpoint.py
+++ b/tests/test_reference_compatibility_endpoint.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+from tools.server.model_manager import ModelManager
+
+
+def test_model_manager_builds_reference_compatibility_snapshot():
+    with TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        llama_dir = root / "llama"
+        llama_dir.mkdir()
+        decoder_path = root / "codec.pth"
+        decoder_path.write_bytes(b"codec-weights")
+
+        (llama_dir / "config.json").write_text(
+            json.dumps({"semantic_start_token_id": 1024}), encoding="utf-8"
+        )
+        (llama_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+
+        manager = ModelManager.__new__(ModelManager)
+        manager.llama_checkpoint_path = llama_dir
+        manager.decoder_checkpoint_path = decoder_path
+        manager.decoder_config_name = "modded_dac_vq"
+        manager.decoder_model = SimpleNamespace(
+            sample_rate=24000,
+            quantizer=SimpleNamespace(n_codebooks=2),
+        )
+
+        snapshot = manager.get_reference_compatibility_snapshot()
+
+        assert snapshot.artifact_schema_version == 1
+        assert snapshot.decoder_config_name == "modded_dac_vq"
+        assert snapshot.num_codebooks == 3
+        assert snapshot.semantic_begin_id == 1024
+        assert snapshot.sample_rate_hz == 24000
+        assert snapshot.codec_checkpoint_sha256.startswith("sha256:")
+        assert snapshot.text2semantic_checkpoint_sha256.startswith("sha256:")
+        assert snapshot.tokenizer_sha256.startswith("sha256:")

--- a/tests/test_reference_payload_resolution.py
+++ b/tests/test_reference_payload_resolution.py
@@ -44,8 +44,8 @@ def test_resolve_reference_payload_accepts_valid_payload():
     engine = _engine()
     payload = _payload(compatibility=_compatibility())
 
-    prompt_tokens, prompt_texts, reference_fingerprint = engine.resolve_reference_payload(
-        payload
+    prompt_tokens, prompt_texts, reference_fingerprint = (
+        engine.resolve_reference_payload(payload)
     )
 
     assert prompt_texts == ["Hello there."]

--- a/tests/test_reference_payload_resolution.py
+++ b/tests/test_reference_payload_resolution.py
@@ -1,0 +1,83 @@
+from fish_speech.inference_engine import TTSInferenceEngine
+from fish_speech.utils.schema import (
+    ServeReferenceCompatibility,
+    ServeReferencePayload,
+)
+
+
+def _compatibility(
+    codec_checkpoint_sha256: str = "sha256:codec",
+) -> ServeReferenceCompatibility:
+    return ServeReferenceCompatibility(
+        artifact_schema_version=1,
+        codec_checkpoint_sha256=codec_checkpoint_sha256,
+        decoder_config_name="modded_dac_vq",
+        text2semantic_checkpoint_sha256="sha256:llama",
+        tokenizer_sha256="sha256:tokenizer",
+        num_codebooks=3,
+        semantic_begin_id=1024,
+        sample_rate_hz=24000,
+    )
+
+
+def _payload(
+    *,
+    compatibility: ServeReferenceCompatibility,
+    reference_fingerprint: str | None = None,
+) -> ServeReferencePayload:
+    return ServeReferencePayload(
+        reference_id="debug-sky",
+        reference_text="Hello there.",
+        prompt_tokens=[[1, 2], [3, 4], [5, 6]],
+        reference_fingerprint=reference_fingerprint,
+        compatibility=compatibility,
+    )
+
+
+def _engine() -> TTSInferenceEngine:
+    engine = TTSInferenceEngine.__new__(TTSInferenceEngine)
+    engine.reference_compatibility = _compatibility()
+    return engine
+
+
+def test_resolve_reference_payload_accepts_valid_payload():
+    engine = _engine()
+    payload = _payload(compatibility=_compatibility())
+
+    prompt_tokens, prompt_texts, reference_fingerprint = engine.resolve_reference_payload(
+        payload
+    )
+
+    assert prompt_texts == ["Hello there."]
+    assert len(prompt_tokens) == 1
+    assert prompt_tokens[0].shape == (3, 2)
+    assert reference_fingerprint.startswith("sha256:")
+
+
+def test_resolve_reference_payload_rejects_compatibility_mismatch():
+    engine = _engine()
+    payload = _payload(
+        compatibility=_compatibility(codec_checkpoint_sha256="sha256:other")
+    )
+
+    try:
+        engine.resolve_reference_payload(payload)
+    except ValueError as exc:
+        assert "compatibility mismatch" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for mismatched compatibility")
+
+
+def test_resolve_reference_payload_rejects_fingerprint_mismatch():
+    engine = _engine()
+    payload = _payload(
+        compatibility=_compatibility(),
+        reference_fingerprint="sha256:not-the-real-fingerprint",
+    )
+
+    try:
+        engine.resolve_reference_payload(payload)
+    except ValueError as exc:
+        assert "fingerprint mismatch" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for mismatched fingerprint")

--- a/tests/test_tts_request_schema.py
+++ b/tests/test_tts_request_schema.py
@@ -1,0 +1,36 @@
+from fish_speech.utils.schema import (
+    ServeReferenceAudio,
+    ServeReferenceCompatibility,
+    ServeReferencePayload,
+    ServeTTSRequest,
+)
+
+
+def _payload() -> ServeReferencePayload:
+    return ServeReferencePayload(
+        reference_id="debug-sky",
+        reference_text="Hello there.",
+        prompt_tokens=[[1, 2], [3, 4], [5, 6]],
+        reference_fingerprint="sha256:test",
+        compatibility=ServeReferenceCompatibility(
+            artifact_schema_version=1,
+            codec_checkpoint_sha256="sha256:codec",
+            decoder_config_name="modded_dac_vq",
+            text2semantic_checkpoint_sha256="sha256:llama",
+            tokenizer_sha256="sha256:tokenizer",
+            num_codebooks=3,
+            semantic_begin_id=1024,
+            sample_rate_hz=24000,
+        ),
+    )
+
+
+def test_effective_reference_source_prefers_reference_payload():
+    request = ServeTTSRequest(
+        text="Say hello",
+        references=[ServeReferenceAudio(audio=b"audio", text="hello")],
+        reference_id="legacy-id",
+        reference_payload=_payload(),
+    )
+
+    assert request.effective_reference_source() == "reference_payload"

--- a/tools/server/model_manager.py
+++ b/tools/server/model_manager.py
@@ -1,10 +1,14 @@
+import json
+from hashlib import sha256
+from pathlib import Path
+
 import torch
 from loguru import logger
 
 from fish_speech.inference_engine import TTSInferenceEngine
 from fish_speech.models.dac.inference import load_model as load_decoder_model
 from fish_speech.models.text2semantic.inference import launch_thread_safe_queue
-from fish_speech.utils.schema import ServeTTSRequest
+from fish_speech.utils.schema import ServeReferenceCompatibility, ServeTTSRequest
 from tools.server.inference import inference_wrapper as inference
 
 
@@ -24,6 +28,9 @@ class ModelManager:
         self.device = device
         self.half = half
         self.compile = compile
+        self.llama_checkpoint_path = Path(llama_checkpoint_path)
+        self.decoder_checkpoint_path = Path(decoder_checkpoint_path)
+        self.decoder_config_name = decoder_config_name
 
         self.precision = torch.half if half else torch.bfloat16
 
@@ -47,6 +54,7 @@ class ModelManager:
             decoder_model=self.decoder_model,
             precision=self.precision,
             compile=self.compile,
+            reference_compatibility=self.get_reference_compatibility_snapshot(),
         )
 
         # Warm up the models
@@ -91,3 +99,100 @@ class ModelManager:
         )
         list(inference(request, tts_inference_engine))
         logger.info("Models warmed up.")
+
+    @staticmethod
+    def _sha256_file(path: Path) -> str:
+        digest = sha256()
+        with path.open("rb") as file_handle:
+            for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+
+    @staticmethod
+    def _sha256_manifest(path: Path) -> str:
+        digest = sha256()
+        for child in sorted(path.rglob("*")):
+            if not child.is_file():
+                continue
+            rel = str(child.relative_to(path)).replace("\\", "/")
+            stat = child.stat()
+            digest.update(rel.encode("utf-8"))
+            digest.update(stat.st_size.to_bytes(8, "little"))
+        return f"sha256:{digest.hexdigest()}"
+
+    def _tokenizer_sha256(self) -> str:
+        tokenizer_files = [
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "special_tokens_map.json",
+            "added_tokens.json",
+            "vocab.json",
+            "merges.txt",
+        ]
+        existing = [
+            self.llama_checkpoint_path / name
+            for name in tokenizer_files
+            if (self.llama_checkpoint_path / name).is_file()
+        ]
+        if not existing:
+            return self._sha256_manifest(self.llama_checkpoint_path)
+
+        digest = sha256()
+        for tokenizer_file in existing:
+            digest.update(tokenizer_file.name.encode("utf-8"))
+            with tokenizer_file.open("rb") as file_handle:
+                for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+
+    def _semantic_begin_id(self) -> int:
+        config_path = self.llama_checkpoint_path / "config.json"
+        if not config_path.is_file():
+            return 0
+
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+        except Exception:
+            return 0
+
+        return int(data.get("semantic_start_token_id", 0))
+
+    def _reference_num_codebooks(self) -> int:
+        quantizer = getattr(self.decoder_model, "quantizer", None)
+        if quantizer is None:
+            raise AttributeError("Decoder model is missing quantizer")
+
+        direct = getattr(quantizer, "n_codebooks", None)
+        if direct is not None:
+            return int(direct) + 1
+
+        residual_quantizer = getattr(quantizer, "quantizer", None)
+        residual_n_codebooks = getattr(residual_quantizer, "n_codebooks", None)
+        if residual_n_codebooks is not None:
+            return int(residual_n_codebooks) + 1
+
+        codebooks = getattr(residual_quantizer, "codebooks", None)
+        if codebooks is not None:
+            return len(codebooks) + 1
+
+        raise AttributeError(
+            "Unable to determine decoder quantizer codebook count for reference compatibility"
+        )
+
+    def get_reference_compatibility_snapshot(self) -> ServeReferenceCompatibility:
+        sample_rate_hz = getattr(self.decoder_model, "sample_rate", None)
+        if sample_rate_hz is None and hasattr(self.decoder_model, "spec_transform"):
+            sample_rate_hz = self.decoder_model.spec_transform.sample_rate
+
+        return ServeReferenceCompatibility(
+            artifact_schema_version=1,
+            codec_checkpoint_sha256=self._sha256_file(self.decoder_checkpoint_path),
+            decoder_config_name=self.decoder_config_name,
+            text2semantic_checkpoint_sha256=self._sha256_manifest(
+                self.llama_checkpoint_path
+            ),
+            tokenizer_sha256=self._tokenizer_sha256(),
+            num_codebooks=self._reference_num_codebooks(),
+            semantic_begin_id=self._semantic_begin_id(),
+            sample_rate_hz=int(sample_rate_hz),
+        )

--- a/tools/server/views.py
+++ b/tools/server/views.py
@@ -29,6 +29,8 @@ from fish_speech.utils.schema import (
     AddReferenceResponse,
     DeleteReferenceResponse,
     ListReferencesResponse,
+    ReferenceCompatibilityResponse,
+    ServeReferenceCompatibility,
     ServeTTSRequest,
     ServeVQGANDecodeRequest,
     ServeVQGANDecodeResponse,
@@ -311,6 +313,43 @@ async def list_references():
         logger.error(f"Unexpected error listing references: {e}", exc_info=True)
         response = ListReferencesResponse(
             success=False, reference_ids=[], message="Internal server error occurred"
+        )
+        return format_response(response, status_code=500)
+
+
+@routes.http.get("/v1/references/compatibility")
+async def get_reference_compatibility():
+    """
+    Get the current runtime reference compatibility contract.
+    """
+    try:
+        app_state = request.app.state
+        model_manager: ModelManager = app_state.model_manager
+        compatibility = ServeReferenceCompatibility.model_validate(
+            model_manager.get_reference_compatibility_snapshot()
+        )
+        response = ReferenceCompatibilityResponse(
+            success=True,
+            compatibility=compatibility,
+        )
+        return format_response(response)
+
+    except Exception as e:
+        logger.error("Unexpected error getting reference compatibility", exc_info=True)
+        compatibility = ServeReferenceCompatibility(
+            artifact_schema_version=1,
+            codec_checkpoint_sha256="sha256:unknown",
+            decoder_config_name="unknown",
+            text2semantic_checkpoint_sha256="sha256:unknown",
+            tokenizer_sha256="sha256:unknown",
+            num_codebooks=1,
+            semantic_begin_id=0,
+            sample_rate_hz=1,
+        )
+        response = ReferenceCompatibilityResponse(
+            success=False,
+            compatibility=compatibility,
+            message=str(e),
         )
         return format_response(response, status_code=500)
 


### PR DESCRIPTION
## Summary

This PR adds a new API path for reusing pre-encoded reference prompts in `/v1/tts`.

Today, callers have two practical options:

- send raw `references` audio + transcript on each request
- persist a legacy `reference_id` inside the Fish server

This PR adds a third option:

- send a full `reference_payload` directly to `/v1/tts`

It also adds:

- `GET /v1/references/compatibility`

That endpoint returns the runtime compatibility contract a reusable prompt bundle must match.

The important design choice here is that `/v1/vqgan/encode` stays a pure transform:
- it returns tokens only
- it does not become a persistence API
- clients fetch compatibility separately and build/store the reusable prompt bundle on their side

## Why this is useful

This unlocks a cleaner integration pattern for worker-based and batched TTS systems.

A consumer can:

1. call `/v1/vqgan/encode` once for a reference audio
2. call `/v1/references/compatibility`
3. store the resulting prompt bundle in its own backend
4. reuse that bundle in every `/v1/tts` call via `reference_payload`

That has a few advantages:

- avoids resending and re-parsing reference audio for repeated requests
- avoids re-encoding the same reference audio during TTS
- works well in stateless worker fleets and queue-driven systems
- lets external services own prompt-bundle persistence without requiring new server-side reference storage
- makes debugging and reproduction easier because the exact prompt bundle can be replayed directly

In other words: this keeps Fish’s server API simple, but makes it much easier to use Fish as part of a larger production pipeline.

## What changed

### New `/v1/tts` input
`ServeTTSRequest` now accepts:

- `reference_payload`

The server resolves reference inputs with this precedence:

1. `reference_payload`
2. `references`
3. `reference_id`

So if `reference_payload` is present, the server ignores inline `references` and `reference_id`.

### New compatibility endpoint
Added:

- `GET /v1/references/compatibility`

This returns the current runtime contract for reusable prompt bundles, including fields such as:

- `artifact_schema_version`
- `codec_checkpoint_sha256`
- `decoder_config_name`
- `text2semantic_checkpoint_sha256`
- `tokenizer_sha256`
- `num_codebooks`
- `semantic_begin_id`
- `sample_rate_hz`

### Validation
`reference_payload` is validated before inference:

- compatibility must match the running server
- `prompt_tokens` must match `num_codebooks`
- if `reference_fingerprint` is provided, it must match the recomputed fingerprint

## Example flow

### 1. Encode reference audio once
`POST /v1/vqgan/encode`

### 2. Fetch runtime compatibility
`GET /v1/references/compatibility`

### 3. Build/store a reusable prompt bundle
Example shape:

```json
{
  "reference_id": "debug-sky",
  "reference_text": "Hello there.",
  "prompt_tokens": [[1, 2], [3, 4], [5, 6]],
  "reference_fingerprint": "sha256:...",
  "compatibility": {
    "artifact_schema_version": 1,
    "codec_checkpoint_sha256": "sha256:...",
    "decoder_config_name": "modded_dac_vq",
    "text2semantic_checkpoint_sha256": "sha256:...",
    "tokenizer_sha256": "sha256:...",
    "num_codebooks": 3,
    "semantic_begin_id": 1024,
    "sample_rate_hz": 24000
  }
}
