### PR TITLE
fix: use importlib to avoid torchaudio local variable scoping bug

### DIFF
--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -44,8 +44,11 @@ class ReferenceLoader:
         except AttributeError:
             # torchaudio 2.9+ removed list_audio_backends()
             # Try ffmpeg first, fallback to soundfile
+            # Use importlib to avoid 'import torchaudio.io...' creating a local
+            # binding that shadows the module-level torchaudio global.
             try:
-                import torchaudio.io._load_audio_fileobj  # noqa: F401
+                import importlib
+                importlib.import_module('torchaudio.io._load_audio_fileobj')
 
                 self.backend = "ffmpeg"
             except (ImportError, ModuleNotFoundError):

--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -48,7 +48,8 @@ class ReferenceLoader:
             # binding that shadows the module-level torchaudio global.
             try:
                 import importlib
-                importlib.import_module('torchaudio.io._load_audio_fileobj')
+
+                importlib.import_module("torchaudio.io._load_audio_fileobj")
 
                 self.backend = "ffmpeg"
             except (ImportError, ModuleNotFoundError):


### PR DESCRIPTION
## Summary
- `import torchaudio.io._load_audio_fileobj` in `ReferenceLoader.__init__` creates a local `torchaudio` binding that shadows the module-level global for the entire method
- Python determines variable scope at compile time, so line 39 (`torchaudio.list_audio_backends()`) tries to access the unbound local instead of the module global
- This manifests as `local variable 'torchaudio' referenced before assignment` when the module is loaded in contexts that swap `sys.modules` (e.g., multi-engine TTS frameworks)

## Fix
Replace `import torchaudio.io._load_audio_fileobj` with `importlib.import_module('torchaudio.io._load_audio_fileobj')` which achieves the same effect without creating a local name binding.

## Test plan
- [x] Verified Fish Speech S2 Pro loads and synthesizes successfully after fix
- [x] Tested in Ultimate-TTS-Studio (14-engine framework with S1/S2 module isolation)
- [x] torchaudio 2.7.0+cu128, Python 3.11, CUDA 12.8

Generated with [Claude Code](https://claude.com/claude-code)