### PR TITLE
fix: update broken import in quantize tool

### DIFF
--- a/tools/llama/quantize.py
+++ b/tools/llama/quantize.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from fish_speech.models.text2semantic.inference import load_model
+from fish_speech.models.text2semantic.inference import init_model
 from fish_speech.models.text2semantic.llama import find_multiple
 
 ##### Quantization Primitives ######
@@ -445,7 +445,7 @@ def quantize(checkpoint_path: Path, mode: str, groupsize: int, timestamp: str) -
     print("Loading model ...")
     t0 = time.time()
 
-    model, _ = load_model(
+    model, _ = init_model(
         checkpoint_path=checkpoint_path,
         device=device,
         precision=precision,


### PR DESCRIPTION
## Summary

- Fix `ImportError` in `tools/llama/quantize.py` — `load_model` was renamed to `init_model` in `fish_speech.models.text2semantic.inference`, breaking the quantization tool

## Steps to Reproduce

```bash
python tools/llama/quantize.py --checkpoint-path checkpoints/s2-pro --mode int8
# ImportError: cannot import name 'load_model' from 'fish_speech.models.text2semantic.inference'
```

## Fix

Two-line change: update the import and call site from `load_model` → `init_model`.

Closes #1248