### PR TITLE
fix: avoid torchaudio shadowing in backend probe

### DIFF
--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -45,7 +45,8 @@ class ReferenceLoader:
             # torchaudio 2.9+ removed list_audio_backends()
             # Try ffmpeg first, fallback to soundfile
             try:
-                import torchaudio.io._load_audio_fileobj  # noqa: F401
+                import importlib
+                importlib.import_module("torchaudio.io._load_audio_fileobj")
 
                 self.backend = "ffmpeg"
             except (ImportError, ModuleNotFoundError):

--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -46,6 +46,7 @@ class ReferenceLoader:
             # Try ffmpeg first, fallback to soundfile
             try:
                 import importlib
+
                 importlib.import_module("torchaudio.io._load_audio_fileobj")
 
                 self.backend = "ffmpeg"

--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -1,3 +1,4 @@
+import importlib
 import io
 import re
 from hashlib import sha256
@@ -45,12 +46,10 @@ class ReferenceLoader:
             # torchaudio 2.9+ removed list_audio_backends()
             # Try ffmpeg first, fallback to soundfile
             try:
-                import importlib
-
                 importlib.import_module("torchaudio.io._load_audio_fileobj")
 
                 self.backend = "ffmpeg"
-            except (ImportError, ModuleNotFoundError):
+            except ImportError:
                 self.backend = "soundfile"
 
     @staticmethod

--- a/tools/vqgan/extract_vq.py
+++ b/tools/vqgan/extract_vq.py
@@ -34,7 +34,8 @@ except AttributeError:
     # torchaudio 2.9+ removed list_audio_backends()
     # Try ffmpeg first, fallback to soundfile
     try:
-        import torchaudio.io._load_audio_fileobj  # Check if ffmpeg backend is available
+        import importlib
+        importlib.import_module("torchaudio.io._load_audio_fileobj")
 
         backend = "ffmpeg"
     except (ImportError, ModuleNotFoundError):

--- a/tools/vqgan/extract_vq.py
+++ b/tools/vqgan/extract_vq.py
@@ -35,6 +35,7 @@ except AttributeError:
     # Try ffmpeg first, fallback to soundfile
     try:
         import importlib
+
         importlib.import_module("torchaudio.io._load_audio_fileobj")
 
         backend = "ffmpeg"

--- a/tools/vqgan/extract_vq.py
+++ b/tools/vqgan/extract_vq.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import subprocess as sp
 import sys
@@ -34,12 +35,10 @@ except AttributeError:
     # torchaudio 2.9+ removed list_audio_backends()
     # Try ffmpeg first, fallback to soundfile
     try:
-        import importlib
-
         importlib.import_module("torchaudio.io._load_audio_fileobj")
 
         backend = "ffmpeg"
-    except (ImportError, ModuleNotFoundError):
+    except ImportError:
         backend = "soundfile"
 
 RANK = int(os.environ.get("SLURM_PROCID", 0))


### PR DESCRIPTION
This fixes a runtime `UnboundLocalError` caused by local shadowing of `torchaudio`
while probing the audio backend.

Reproduced with:

- Docker image: `fishaudio/fish-speech:server-cuda@sha256:458725b7bffa3e8def159ec90c5a2d8b73e1d8a83c7b110e5affc271032ef71e`

```bash
uv run --no-sync tools/api_server.py \
	--listen 0.0.0.0:8080 \
	--device cuda \
	--half \
	--llama-checkpoint-path /app/checkpoints/s2-pro \
	--decoder-checkpoint-path /app/checkpoints/s2-pro/codec.pth \
	--decoder-config-name modded_dac_vq
```

The issue comes from this pattern inside local scope:

```py
import torchaudio.io._load_audio_fileobj
```

That can break earlier access to `torchaudio` in the same scope with:

```text
UnboundLocalError: cannot access local variable 'torchaudio' where it is not associated with a value
```

This PR replaces it with:

```py
import importlib
importlib.import_module("torchaudio.io._load_audio_fileobj")
```