### PR TITLE
Fix #1250: UnboundLocalError: local variable 'torchaudio' referenced ...

### DIFF
--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -45,7 +45,7 @@ class ReferenceLoader:
             # torchaudio 2.9+ removed list_audio_backends()
             # Try ffmpeg first, fallback to soundfile
             try:
-                import torchaudio.io._load_audio_fileobj  # noqa: F401
+                __import__("torchaudio.io._load_audio_fileobj")
 
                 self.backend = "ffmpeg"
             except (ImportError, ModuleNotFoundError):


### PR DESCRIPTION
Closes #1250

**Is this PR adding new feature or fix a BUG?**

Fix BUG.

**Is this pull request related to any issue? If yes, please link the issue.**

#1250

In `fish_speech/inference_engine/reference_loader.py`, the `except AttributeError` block (triggered when `torchaudio.list_audio_backends()` doesn't exist in torchaudio 2.8.x) contained a bare `import torchaudio.io._load_audio_fileobj` statement. Python's scoping rules treat any `import torchaudio` variant inside a function as a local variable declaration, which shadows the module-level `import torchaudio` at line 8. This causes the earlier `torchaudio.list_audio_backends()` call on line 39 to raise `UnboundLocalError: local variable 'torchaudio' referenced before assignment` instead of the expected `AttributeError`.

The fix replaces `import torchaudio.io._load_audio_fileobj` with `__import__("torchaudio.io._load_audio_fileobj")`, which performs the same runtime import without introducing a local variable binding for `torchaudio`, preserving the module-level reference throughout the method.

Verified by running `python -m tools.api_server` on torchaudio 2.8.0+cu128 — server now starts successfully and reaches the ready state without the `UnboundLocalError`.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*