### PR TITLE
inference: defensive --compile guard for Blackwell B300 + stable PyTorch

### DIFF
--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -380,7 +380,8 @@ def init_model(checkpoint_path, device, precision, compile=False):
     # Mark whether cache has been initialized
     model._cache_setup_done = False
 
-    if compile:
+    compile_ok, compile_skip_reason = _can_safely_compile()
+    if compile and compile_ok:
         logger.info("Compiling function...")
         decode_one_token = torch.compile(
             decode_one_token,
@@ -388,8 +389,52 @@ def init_model(checkpoint_path, device, precision, compile=False):
             mode="default" if torch.cuda.is_available() else None,
             fullgraph=True,
         )
+    elif compile:
+        # User asked for --compile but the toolchain can't deliver. Warn
+        # loudly + run eager rather than 500-loop on every request.
+        logger.warning(compile_skip_reason)
 
     return model.eval(), decode_one_token
+
+
+def _can_safely_compile() -> tuple[bool, str]:
+    """Returns (compile_ok, rationale).
+
+    Auto-disables ``torch.compile`` on hardware/software combinations
+    known to fail at codegen time. Today the only blocked combination
+    is NVIDIA Blackwell B300 (compute capability 10.3 / sm_103a) on
+    stable PyTorch < 2.11.dev — the bundled Triton's PTXAS does not
+    recognize sm_103a and emits ``Internal Triton PTX codegen error``
+    on every compile attempt. Fix: ``torch`` nightly with cu130 index.
+
+    Refs: PyTorch Discuss Dec-2025; Triton issues #9181, #8539, #8632.
+    """
+    if not torch.cuda.is_available():
+        return True, ""
+    try:
+        cap = torch.cuda.get_device_capability(0)
+    except Exception:  # pragma: no cover - defensive
+        return True, ""
+    if cap != (10, 3):
+        return True, ""
+    # B300 detected. Check torch version.
+    try:
+        major_str, minor_str = torch.__version__.split(".")[:2]
+        major = int(major_str)
+        minor = int(minor_str)
+        if major > 2 or (major == 2 and minor >= 11):
+            return True, ""
+    except (ValueError, AttributeError):  # pragma: no cover - defensive
+        return True, ""
+    return False, (
+        f"NVIDIA Blackwell B300 (sm_103) detected with torch "
+        f"{torch.__version__}. Stable PyTorch < 2.11 has a bundled-"
+        f"Triton/PTXAS regression that fails 'Internal Triton PTX "
+        f"codegen error' on sm_103a. Auto-disabling --compile. Install "
+        f"torch nightly (>=2.11.dev) with --index-url "
+        f"https://download.pytorch.org/whl/nightly/cu130 to enable "
+        f"compile on B300."
+    )
 
 
 @torch.inference_mode()


### PR DESCRIPTION
## Summary

Adds a startup-time safety check around `torch.compile(decode_one_token, ...)`. On NVIDIA Blackwell B300 (compute capability 10.3 / sm_103a), stable PyTorch (<2.11.dev) bundles a Triton whose PTXAS does not recognize sm_103a. Engaging `--compile` triggers:

```
torch._inductor.exc.InductorError: SubprocException:
  torch._inductor.runtime.triton_heuristics.NoTritonConfigsError:
  No valid triton configs.
  PTXASError: PTXAS error: Internal Triton PTX codegen error
```

…on first inference, serving HTTP 500 on every TTS request until rollback.

**Without this guard**: operator runs \`python tools/api_server.py --compile\`, sees Fish load successfully, then every request returns 500. Recovery requires rolling back the systemd unit / docker image (5–15 min outage).

**With this guard**: operator gets an actionable warning at startup ("install torch nightly to enable --compile on B300") and Fish falls back to PyTorch eager mode. No outage; no surprise.

## Why this is upstream-worthy

Defensive infrastructure for the open-source community. Every Blackwell B300 deployment using \`torch.compile\` will hit this until upstream PyTorch nightly lands in stable. Fish-speech is the canonical OSS TTS for B300 deployments; baking the guard upstream prevents a recurring failure mode for every operator who attempts the natural optimization path.

The patch does NOT fix the underlying PyTorch-Triton-PTXAS gap. It prevents fish-speech operators from hitting a 500-on-every-request failure mode and tells them how to recover.

## Verification

Verified by direct B300 deployment (2026-04-25):

- Without patch + \`--compile\`: Fish loads → first inference triggers \`InductorError\` → all subsequent requests return 500 until rollback.
- With patch + \`--compile\` + stable torch on B300: Startup logs the warning, falls back to eager mode, all requests serve normally.
- With patch + \`--compile\` + non-B300 hardware: behaves identically to unpatched code (no-op).
- With patch + \`--compile\` + nightly torch (≥2.11.dev) on B300: compile engages normally.

Full discovery write-up + reproducer + citations: [GOATnote-Inc/prism42 docs/livekit-kb/20-blackwell-b300-torch-compile-discovery.md](https://github.com/GOATnote-Inc/prism42/blob/main/docs/livekit-kb/20-blackwell-b300-torch-compile-discovery.md).

## References

- PyTorch Discuss (Dec 2025): _"current stable torch (2.9.1+cu130) points to a Triton version where PTXAS is not compiled for SM103"_
- triton-lang/triton#9181 — \`ptxas: sm_121a is not defined\` (same class)
- triton-lang/triton#8539 — same class

## Footprint

- One file: \`fish_speech/models/text2semantic/inference.py\` (+46/-1)
- New private helper \`_can_safely_compile() -> tuple[bool, str]\`
- No new dependencies; uses only \`torch.__version__\` + \`torch.cuda.get_device_capability()\`

🤖 Authored via Claude Code multi-agent harness on Anthropic Opus 4.7.