### PR TITLE
security: torch.load(weights_only=True) on all explicit-load sites

### DIFF
--- a/fish_speech/models/dac/modded_dac.py
+++ b/fish_speech/models/dac/modded_dac.py
@@ -1013,7 +1013,7 @@ if __name__ == "__main__":
     with torch.inference_mode():
         # 1. 初始化模型
         model = hydra.utils.instantiate(OmegaConf.load(config_path))
-        new_sd = torch.load(checkpoint_path, map_location="cpu")
+        new_sd = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
         model.load_state_dict(new_sd, strict=False)
         model.cuda()
         model.eval()

--- a/tests/test_pickle_rce_guard.py
+++ b/tests/test_pickle_rce_guard.py
@@ -1,0 +1,105 @@
+"""Regression tests for the torch.load(weights_only=True) hardening.
+
+Each Fish-Speech tool/model checkpoint loader explicitly opts into
+`weights_only=True` so a malicious pickle payload in a swapped
+checkpoint cannot achieve arbitrary code execution as the loader
+process. This test builds a `__reduce__`-based pickle bomb and
+verifies that `torch.load(...)` rejects it with UnpicklingError —
+i.e., the canary file the bomb tries to create never appears.
+
+Source finding: caller-controlled or supply-chain-substituted
+checkpoint paths can land at four sites in the upstream repo:
+  - tools/llama/merge_lora.py (LoRA weight + post-merge readback)
+  - fish_speech/models/dac/modded_dac.py (DAC inference checkpoint)
+  - tools/vqgan/extract_vq.py (VQGAN checkpoint)
+
+PyTorch 2.6+ defaults `weights_only=True`, so sites without an
+explicit kwarg are safe by default. The fixed sites either had
+explicit `weights_only=False` (merge_lora.py:43) or are
+defense-in-depth on call sites that historically passed kwargs
+inconsistently.
+"""
+from __future__ import annotations
+
+import os
+import pickle
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+
+
+_CANARY_DIR = Path(tempfile.gettempdir())
+
+
+class _PickleRCEPayload:
+    """Pickle payload that creates a canary file when deserialized.
+
+    Pure local-fixture exploit class. No network, no shell, no
+    persistence; only writes a single canary file path that the
+    test asserts the absence of.
+    """
+
+    def __init__(self, canary_path: Path):
+        self._canary_path = canary_path
+
+    def __reduce__(self):
+        # When unpickled in a non-weights-only context, this calls
+        # `os.system` (or equivalent) to write the canary file.
+        # Using `subprocess` keeps the call observable + cancellable.
+        cmd = (
+            f"{sys.executable} -c "
+            f"\"open({str(self._canary_path)!r}, 'w').write('vulnerable')\""
+        )
+        return (subprocess.run, ([cmd], {"shell": True, "check": False}))
+
+
+def _make_malicious_checkpoint(canary: Path) -> Path:
+    payload = _PickleRCEPayload(canary)
+    fp = tempfile.NamedTemporaryFile(suffix=".pt", delete=False)
+    fp.close()
+    # Use plain pickle so the payload survives torch.save's wrapping;
+    # torch.load reads pickle either way under the default
+    # zipfile-or-pickle dispatcher.
+    with open(fp.name, "wb") as f:
+        pickle.dump(payload, f)
+    return Path(fp.name)
+
+
+@pytest.fixture
+def malicious_checkpoint():
+    canary = _CANARY_DIR / "POC_TRIGGERED_test_pickle_rce_guard.txt"
+    if canary.exists():
+        canary.unlink()
+    ckpt = _make_malicious_checkpoint(canary)
+    yield ckpt, canary
+    if ckpt.exists():
+        ckpt.unlink()
+    if canary.exists():
+        canary.unlink()
+
+
+def test_weights_only_blocks_pickle_rce(malicious_checkpoint):
+    """torch.load(..., weights_only=True) must raise rather than execute."""
+    ckpt, canary = malicious_checkpoint
+    with pytest.raises((pickle.UnpicklingError, RuntimeError, ValueError)):
+        torch.load(ckpt, map_location="cpu", weights_only=True)
+    assert not canary.exists(), (
+        "PoC canary appeared — torch.load did not block pickle deserialization. "
+        "weights_only=True is not enforced at this call site."
+    )
+
+
+def test_weights_only_default_blocks_in_torch_2_6_plus(malicious_checkpoint):
+    """On torch>=2.6, the default is weights_only=True, so call sites
+    that omit the kwarg are also safe. Test the default path."""
+    ckpt, canary = malicious_checkpoint
+    torch_version = tuple(int(p) for p in torch.__version__.split(".")[:2])
+    if torch_version < (2, 6):
+        pytest.skip(f"torch {torch.__version__} default is weights_only=False")
+    with pytest.raises((pickle.UnpicklingError, RuntimeError, ValueError)):
+        torch.load(ckpt, map_location="cpu")  # no kwarg = default
+    assert not canary.exists()

--- a/tools/llama/merge_lora.py
+++ b/tools/llama/merge_lora.py
@@ -40,7 +40,9 @@ def merge(lora_config, base_weight, lora_weight, output):
     llama_state_dict = llama_model.state_dict()
     llama_state_dict = {k: v for k, v in llama_state_dict.items() if "lora" not in k}
     llama_state_dict_copy = deepcopy(llama_state_dict)
-    lora_state_dict = torch.load(lora_weight, map_location="cpu", weights_only=False)
+    # Use weights_only=True to block pickle-RCE via crafted LoRA checkpoints.
+    # LoRA state dicts are tensor-only — no pickle objects required.
+    lora_state_dict = torch.load(lora_weight, map_location="cpu", weights_only=True)
 
     if "state_dict" in llama_state_dict:
         llama_state_dict = llama_state_dict["state_dict"]
@@ -74,7 +76,7 @@ def merge(lora_config, base_weight, lora_weight, output):
     llama_model.save_pretrained(output, drop_lora=True)
     logger.info(f"Saved merged model to {output}, validating")
 
-    new_state_dict = torch.load(output / "model.pth", map_location="cpu")
+    new_state_dict = torch.load(output / "model.pth", map_location="cpu", weights_only=True)
     original_keys = set(llama_state_dict_copy.keys())
 
     tolerance = 1e-5

--- a/tools/vqgan/extract_vq.py
+++ b/tools/vqgan/extract_vq.py
@@ -67,6 +67,7 @@ def get_model(
     state_dict = torch.load(
         checkpoint_path,
         map_location=device,
+        weights_only=True,
     )
     if "state_dict" in state_dict:
         state_dict = state_dict["state_dict"]


### PR DESCRIPTION
## Summary

PyTorch 2.6+ flipped the default to \`weights_only=True\`, but four call sites in fish-speech historically opted out or omitted the kwarg. A maintainer or operator loading an attacker-controlled checkpoint (LoRA, DAC, VQGAN — via shared mount, NFS, supply-chain substitution) achieves arbitrary code execution as the loader process via pickle \`__reduce__\` payload.

## Patch

Four sites:

- \`tools/llama/merge_lora.py:43\` — had explicit \`weights_only=False\`; flipped to \`weights_only=True\`. **This is the strongest finding** — explicit opt-out makes the bug present on all torch versions, not just torch<2.6. LoRA state dicts are tensor-only; no pickle objects required.
- \`tools/llama/merge_lora.py:77\` — added \`weights_only=True\` to the post-merge readback validation.
- \`fish_speech/models/dac/modded_dac.py:1016\` — added \`weights_only=True\` to the DAC inference checkpoint loader (defense in depth; safe by torch>=2.6 default but explicit prevents future regression if someone changes the call site).
- \`tools/vqgan/extract_vq.py:67\` — same treatment for VQGAN.

## Test

\`tests/test_pickle_rce_guard.py\` (105 lines): builds a \`__reduce__\`-based pickle bomb checkpoint (writes a canary file in the loader process if executed), asserts \`torch.load(..., weights_only=True)\` raises before the bomb fires, and a second test asserts the torch>=2.6 default-path also blocks.

## References

Originated from a Glasswing-aligned multi-agent security audit of fish-speech checkpoint loading. Audit context (no exploit details): [GOATnote-Inc/prism42 docs](https://github.com/GOATnote-Inc/prism42/blob/main/docs/livekit-kb/19-glasswing-aligned-submission.md).

🤖 Authored via Claude Code multi-agent harness on Anthropic Opus 4.7.