### PR TITLE
docs: add pointer to vLLM Omni for Fish Audio S2 inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Here are the official documents for Fish Audio S2, follow the instructions to ge
 
 > [!IMPORTANT]
 > **For SGLang server, please read [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
+>
+> **For vLLM Omni server, please read [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md).**
 
 ### For LLM Agent
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Here are the official documents for Fish Audio S2, follow the instructions to ge
 > [!IMPORTANT]
 > **For SGLang server, please read [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
 >
-> **For vLLM Omni server, please read [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md).**
+> **For vLLM Omni server, please read [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md) and the [User Guide](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/examples/online_serving/text_to_speech.md#fish-speech-s2-pro).**
 
 ### For LLM Agent
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Here are the official documents for Fish Audio S2, follow the instructions to ge
 > [!IMPORTANT]
 > **For SGLang server, please read [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
 >
-> **For vLLM Omni server, please read [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md).**
+> **For vLLM Omni server, please read [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md).**
 
 ### For LLM Agent
 

--- a/docs/README.ar.md
+++ b/docs/README.ar.md
@@ -64,6 +64,8 @@
 
 > [!IMPORTANT]
 > **إذا كنت ترغب في استخدام خادم SGLang، فيرجى الرجوع إلى [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
+>
+> **إذا كنت ترغب في استخدام خادم vLLM Omni، فيرجى الرجوع إلى [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md).**
 
 ### دليل وكيل LLM
 

--- a/docs/README.ar.md
+++ b/docs/README.ar.md
@@ -65,7 +65,7 @@
 > [!IMPORTANT]
 > **إذا كنت ترغب في استخدام خادم SGLang، فيرجى الرجوع إلى [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
 >
-> **إذا كنت ترغب في استخدام خادم vLLM Omni، فيرجى الرجوع إلى [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md).**
+> **إذا كنت ترغب في استخدام خادم vLLM Omni، فيرجى الرجوع إلى [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md) و[دليل المستخدم](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/examples/online_serving/text_to_speech.md#fish-speech-s2-pro).**
 
 ### دليل وكيل LLM
 

--- a/docs/README.ar.md
+++ b/docs/README.ar.md
@@ -65,7 +65,7 @@
 > [!IMPORTANT]
 > **إذا كنت ترغب في استخدام خادم SGLang، فيرجى الرجوع إلى [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
 >
-> **إذا كنت ترغب في استخدام خادم vLLM Omni، فيرجى الرجوع إلى [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md).**
+> **إذا كنت ترغب في استخدام خادم vLLM Omni، فيرجى الرجوع إلى [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md).**
 
 ### دليل وكيل LLM
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -60,6 +60,8 @@ Aquí tienes la documentación oficial de Fish Audio S2. Sigue las instrucciones
 
 > [!IMPORTANT]
 > **Para el servidor SGLang, consulta [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
+>
+> **Para el servidor vLLM Omni, consulta [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md).**
 
 ### Para agentes LLM
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -61,7 +61,7 @@ Aquí tienes la documentación oficial de Fish Audio S2. Sigue las instrucciones
 > [!IMPORTANT]
 > **Para el servidor SGLang, consulta [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
 >
-> **Para el servidor vLLM Omni, consulta [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md).**
+> **Para el servidor vLLM Omni, consulta [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md).**
 
 ### Para agentes LLM
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -61,7 +61,7 @@ Aquí tienes la documentación oficial de Fish Audio S2. Sigue las instrucciones
 > [!IMPORTANT]
 > **Para el servidor SGLang, consulta [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
 >
-> **Para el servidor vLLM Omni, consulta [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md).**
+> **Para el servidor vLLM Omni, consulta [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md) y la [Guía de usuario](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/examples/online_serving/text_to_speech.md#fish-speech-s2-pro).**
 
 ### Para agentes LLM
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -64,6 +64,8 @@ Fish Audio S2 の公式ドキュメントです。以下からすぐに始めら
 
 > [!IMPORTANT]
 > **SGLang サーバーについては [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md) を参照してください。**
+>
+> **vLLM Omni サーバーについては [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md) を参照してください。**
 
 ### LLM Agent 指南
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -65,7 +65,7 @@ Fish Audio S2 の公式ドキュメントです。以下からすぐに始めら
 > [!IMPORTANT]
 > **SGLang サーバーについては [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md) を参照してください。**
 >
-> **vLLM Omni サーバーについては [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md) を参照してください。**
+> **vLLM Omni サーバーについては [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md) と [ユーザーガイド](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/examples/online_serving/text_to_speech.md#fish-speech-s2-pro) を参照してください。**
 
 ### LLM Agent 指南
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -65,7 +65,7 @@ Fish Audio S2 の公式ドキュメントです。以下からすぐに始めら
 > [!IMPORTANT]
 > **SGLang サーバーについては [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md) を参照してください。**
 >
-> **vLLM Omni サーバーについては [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md) を参照してください。**
+> **vLLM Omni サーバーについては [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md) を参照してください。**
 
 ### LLM Agent 指南
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -64,6 +64,8 @@ Fish Audio S2의 공식 문서입니다. 지침에 따라 쉽게 시작하십시
 
 > [!IMPORTANT]
 > **SGLang 서버를 사용하려면 [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md)를 참조하십시오.**
+>
+> **vLLM Omni 서버를 사용하려면 [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md)를 참조하십시오.**
 
 ### LLM Agent 가이드
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -65,7 +65,7 @@ Fish Audio S2의 공식 문서입니다. 지침에 따라 쉽게 시작하십시
 > [!IMPORTANT]
 > **SGLang 서버를 사용하려면 [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md)를 참조하십시오.**
 >
-> **vLLM Omni 서버를 사용하려면 [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md)를 참조하십시오.**
+> **vLLM Omni 서버를 사용하려면 [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md)를 참조하십시오.**
 
 ### LLM Agent 가이드
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -65,7 +65,7 @@ Fish Audio S2의 공식 문서입니다. 지침에 따라 쉽게 시작하십시
 > [!IMPORTANT]
 > **SGLang 서버를 사용하려면 [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md)를 참조하십시오.**
 >
-> **vLLM Omni 서버를 사용하려면 [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md)를 참조하십시오.**
+> **vLLM Omni 서버를 사용하려면 [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md)와 [사용자 가이드](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/examples/online_serving/text_to_speech.md#fish-speech-s2-pro)를 참조하십시오.**
 
 ### LLM Agent 가이드
 

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -64,6 +64,8 @@ Esta é a documentação oficial do Fish Audio S2, siga as instruções para com
 
 > [!IMPORTANT]
 > **Caso deseje utilizar o SGLang Server, consulte o [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
+>
+> **Caso deseje utilizar o vLLM Omni Server, consulte o [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md).**
 
 ### Guia para Agentes de LLM
 

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -65,7 +65,7 @@ Esta é a documentação oficial do Fish Audio S2, siga as instruções para com
 > [!IMPORTANT]
 > **Caso deseje utilizar o SGLang Server, consulte o [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
 >
-> **Caso deseje utilizar o vLLM Omni Server, consulte o [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md).**
+> **Caso deseje utilizar o vLLM Omni Server, consulte o [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md) e o [Guia do Usuário](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/examples/online_serving/text_to_speech.md#fish-speech-s2-pro).**
 
 ### Guia para Agentes de LLM
 

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -65,7 +65,7 @@ Esta é a documentação oficial do Fish Audio S2, siga as instruções para com
 > [!IMPORTANT]
 > **Caso deseje utilizar o SGLang Server, consulte o [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md).**
 >
-> **Caso deseje utilizar o vLLM Omni Server, consulte o [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md).**
+> **Caso deseje utilizar o vLLM Omni Server, consulte o [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md).**
 
 ### Guia para Agentes de LLM
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -64,6 +64,8 @@
 
 > [!IMPORTANT]
 > **如需使用 SGLang Server，请参考 [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md)。**
+>
+> **如需使用 vLLM Omni Server，请参考 [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md)。**
 
 ### LLM Agent 指南
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -65,7 +65,7 @@
 > [!IMPORTANT]
 > **如需使用 SGLang Server，请参考 [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md)。**
 >
-> **如需使用 vLLM Omni Server，请参考 [vLLM-Omni Fish Speech README](https://github.com/vllm-project/vllm-omni/blob/main/examples/online_serving/fish_speech/README.md)。**
+> **如需使用 vLLM Omni Server，请参考 [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md)。**
 
 ### LLM Agent 指南
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -65,7 +65,7 @@
 > [!IMPORTANT]
 > **如需使用 SGLang Server，请参考 [SGLang-Omni README](https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md)。**
 >
-> **如需使用 vLLM Omni Server，请参考 [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md)。**
+> **如需使用 vLLM Omni Server，请参考 [vLLM-Omni Fish Speech S2 Pro Recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/fishaudio/Fish-Speech-S2-Pro.md) 和[用户指南](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/examples/online_serving/text_to_speech.md#fish-speech-s2-pro)。**
 
 ### LLM Agent 指南
 


### PR DESCRIPTION
## Summary

Hi FishAudio team, we're from the vLLM Omni team (https://github.com/vllm-project/vllm-omni).

Fish Audio S2 is a wonderful TTS model and we've added support for `fishaudio/s2-pro` in vLLM Omni: voice cloning, streaming via the OpenAI-compatible `/v1/audio/speech` endpoint, and a Gradio demo. Performance work is ongoing.

This PR mirrors the existing SGLang-Omni pointer with a parallel link to our docs, consistent with #1240. Documentation only.

Thanks to the FishAudio team for the open release.

cc @hsliuustc0106

## Changes
- `README.md`: add vLLM Omni pointer in the top-level IMPORTANT callout
- `docs/README.{zh,pt-BR,ja,ko,ar,es}.md`: i18n parity

## Test plan
- [ ] Links resolve to the vllm-omni Fish Speech README on `main`
- [ ] All 7 README files updated identically; no markdown lint regressions