### PR TITLE
fix(lora): resume from checkpoint fails due to strict state_dict loading

### DIFF
--- a/fish_speech/models/text2semantic/lit_module.py
+++ b/fish_speech/models/text2semantic/lit_module.py
@@ -29,6 +29,9 @@ class TextToSemantic(L.LightningModule):
     def forward(self, x):
         return self.model(x)
 
+    def load_state_dict(self, state_dict, strict=True, assign=False):
+        return super().load_state_dict(state_dict, strict=False, assign=assign)
+
     def on_save_checkpoint(self, checkpoint):
         # Save only LoRA parameters
         state_dict = checkpoint["state_dict"]


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG.

**Is this pull request related to any issue? If yes, please link the issue.**

#1295

## Problem

`TextToSemantic.on_save_checkpoint` intentionally saves only LoRA parameters to reduce checkpoint size (~100MB vs ~9GB). However, this causes Lightning's `restore_model()` to fail during resume because `load_state_dict` is called with `strict=True`, and the frozen base model weights are missing from the saved state_dict.

## Fix

Override `load_state_dict` in `TextToSemantic` to always use `strict=False`.

- Only LoRA weights are updated (base weights remain from `from_pretrained`)
- Optimizer states and LR schedulers are correctly restored
- Full fine-tuning is unaffected (non-LoRA checkpoints have all keys)

## Before

```
RuntimeError: Error(s) in loading state_dict for TextToSemantic:
	Missing key(s): model.embeddings.weight, model.codebook_embeddings.weight, ...
```

## After

LoRA training resumes from checkpoint with no errors.

## Files changed

- `fish_speech/models/text2semantic/lit_module.py` — add `load_state_dict` override

## Testing

Tested on a single RTX 4090 (48GB) with LoRA r=8 on s2-pro:

1. Train for N steps → interrupt
2. Re-run training script → resume from latest checkpoint successfully
3. Loss curve is continuous, optimizer/scheduler states restored
