### PR TITLE
fix: reject empty TTS text at the schema boundary (Fixes #946)

### DIFF
--- a/fish_speech/utils/schema.py
+++ b/fish_speech/utils/schema.py
@@ -79,7 +79,7 @@ class ServeReferenceAudio(BaseModel):
 
 
 class ServeTTSRequest(BaseModel):
-    text: str
+    text: str = Field(..., min_length=1)
     chunk_length: Annotated[int, conint(ge=100, le=1000, strict=True)] = 200
     # Audio format
     format: Literal["wav", "pcm", "mp3", "opus"] = "wav"


### PR DESCRIPTION
**Is this a feature or a BUG fix?** BUG fix.

**Related issue:** Fixes #946

## Summary

`POST /v1/tts` returns an **HTTP 500 with a JSON error body** when `text` is empty.
A client that streams the response then writes that JSON error into a `.wav` file.

Root cause is a schema asymmetry in `fish_speech/utils/schema.py`:

- `ServeTTSRequest.text` was an **unconstrained `str`**, so an empty string passes
  validation and flows into synthesis.
- Empty text yields zero audio segments, which `TTSInferenceEngine.inference`
  reports as an error and `tools/server/inference.py` re-raises as
  `HTTPException(INTERNAL_SERVER_ERROR)` → the 500 reported in #946
  (`"No audio generated, please check the input text."`).
- The sibling model `AddReferenceRequest.text` **already** constrains
  `min_length=1`, so the asymmetry is the bug.

## The fix

Constrain `ServeTTSRequest.text` the same way, so empty input is rejected with a
clean **4xx validation error at the request boundary** — before any model work:

```python
# fish_speech/utils/schema.py
class ServeTTSRequest(BaseModel):
-    text: str
+    text: str = Field(..., min_length=1)
```

One line, no behavior change for valid input. Matches the existing `min_length=1`
on `AddReferenceRequest.text` and the `Field(...)` constraint style already used on
`ServeTTSRequest` (`top_p`, `temperature`, `repetition_penalty`).

## Validation

The change is pure pydantic validation (no model weights needed). Importing the
model and constructing it:

| Input | Before | After |
|-------|--------|-------|
| `text=""` | accepted → empty segments → **HTTP 500** | **`ValidationError`** (clean 4xx) |
| `text="hello"` | accepted | accepted (unchanged) |

## Scope

This fixes the empty-string trigger at the schema boundary. The broader
"no segments generated → 500" path (e.g. other degenerate inputs) is a separate,
larger change in `tools/server/inference.py` and is intentionally out of scope here.

---

*Disclosure: this fix was drafted with AI assistance (Claude) and reviewed, tested,
and submitted by me. The commit carries a `Co-Authored-By` trailer.*
