### PR TITLE
fix: make pyaudio an optional [client] extra so headless installs work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "einx[torch]==0.2.2",
     "zstandard>=0.22.0",
     "pydub",
-    "pyaudio",
     "modelscope==1.17.1",
     "opencc-python-reimplemented==0.1.7",
     "silero-vad",
@@ -70,6 +69,9 @@ cu129 = [
   "torch==2.8.0",
   "torchaudio",
 ]
+# Optional: native audio playback for the streaming api_client (PyAudio needs
+# system PortAudio headers; keeping it out of core unblocks slim / headless installs).
+client = ["pyaudio"]
 
 [tool.uv]
 override-dependencies = [

--- a/tools/api_client.py
+++ b/tools/api_client.py
@@ -4,7 +4,6 @@ import time
 import wave
 
 import ormsgpack
-import pyaudio
 import requests
 from pydub import AudioSegment
 from pydub.playback import play
@@ -198,6 +197,14 @@ if __name__ == "__main__":
 
     if response.status_code == 200:
         if args.streaming:
+            try:
+                import pyaudio
+            except ImportError:
+                raise ImportError(
+                    "Streaming playback requires PyAudio. Install it with: "
+                    "pip install -e .[client]"
+                )
+
             p = pyaudio.PyAudio()
             audio_format = pyaudio.paInt16  # Assuming 16-bit PCM format
             stream = p.open(


### PR DESCRIPTION
**Move `pyaudio` to an optional `client` extra so headless / slim / API-only installs work.**

`pyaudio` is a core dependency, but it needs the system PortAudio headers
(`portaudio19-dev`) to build — so `pip install` of fish-speech fails on slim
containers, CPU-only boxes, and any environment that only needs the API/server, not
local audio playback. PyAudio is used in exactly one place: native streaming playback
in `tools/api_client.py`.

## Changes
- **`pyproject.toml`** — remove `pyaudio` from core `dependencies`; add a `client`
  optional-dependency group (`client = ["pyaudio"]`).
- **`tools/api_client.py`** — drop the module-level `import pyaudio`; import it lazily
  inside the `--streaming` playback branch, with a friendly `ImportError` pointing to
  `pip install -e .[client]`.

No behavior change for users who already have PyAudio installed; headless/slim installs
now succeed, and only hit the requirement if they actually use streaming playback.

(Same spirit as the input-validation hardening in #1303.)

---
*Disclosure: drafted with AI assistance (Claude); reviewed and submitted by me. The commit carries a `Co-Authored-By` trailer.*
