### PR TITLE
fix: make pyaudio optional for headless/server-only installs

### DIFF
--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -30,6 +30,11 @@ pip install -e .
 # If you encounter an error during installation due to pyaudio, consider using the following command:
 # conda install pyaudio
 # Then run pip install -e . again
+
+# For headless/server-only installs (no audio playback needed), pyaudio is not required.
+# To enable interactive audio playback with the API client, install with the audio extra:
+# pip install -e .[audio]
+# (also requires PortAudio system headers: apt install portaudio19-dev)
 ```
 
 ### UV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "einx[torch]==0.2.2",
     "zstandard>=0.22.0",
     "pydub",
-    "pyaudio",
     "modelscope==1.17.1",
     "opencc-python-reimplemented==0.1.7",
     "silero-vad",
@@ -69,6 +68,12 @@ cu128 = [
 cu129 = [
   "torch==2.8.0",
   "torchaudio",
+]
+# Audio playback support for the interactive API client (tools/api_client.py).
+# Requires PortAudio system headers (e.g. apt install portaudio19-dev).
+# Not needed for headless server deployments.
+audio = [
+    "pyaudio",
 ]
 
 [tool.uv]

--- a/tools/api_client.py
+++ b/tools/api_client.py
@@ -4,7 +4,6 @@ import time
 import wave
 
 import ormsgpack
-import pyaudio
 import requests
 from pydub import AudioSegment
 from pydub.playback import play
@@ -198,32 +197,47 @@ if __name__ == "__main__":
 
     if response.status_code == 200:
         if args.streaming:
-            p = pyaudio.PyAudio()
-            audio_format = pyaudio.paInt16  # Assuming 16-bit PCM format
-            stream = p.open(
-                format=audio_format, channels=args.channels, rate=args.rate, output=True
-            )
-
-            wf = wave.open(f"{args.output}.wav", "wb")
-            wf.setnchannels(args.channels)
-            wf.setsampwidth(p.get_sample_size(audio_format))
-            wf.setframerate(args.rate)
-
-            stream_stopped_flag = False
-
             try:
-                for chunk in response.iter_content(chunk_size=1024):
-                    if chunk:
-                        stream.write(chunk)
-                        wf.writeframesraw(chunk)
-                    else:
-                        if not stream_stopped_flag:
-                            stream.stop_stream()
-                            stream_stopped_flag = True
-            finally:
-                stream.close()
-                p.terminate()
-                wf.close()
+                import pyaudio
+            except ImportError:
+                print(
+                    "Streaming playback requires pyaudio. "
+                    "Install it with: pip install fish-speech[audio] "
+                    "(also requires PortAudio system headers, e.g. apt install portaudio19-dev)"
+                )
+                # Still save the audio to file even without pyaudio
+                audio_content = response.content
+                audio_path = f"{args.output}.wav"
+                with open(audio_path, "wb") as audio_file:
+                    audio_file.write(audio_content)
+                print(f"Audio has been saved to '{audio_path}'.")
+            else:
+                p = pyaudio.PyAudio()
+                audio_format = pyaudio.paInt16  # Assuming 16-bit PCM format
+                stream = p.open(
+                    format=audio_format, channels=args.channels, rate=args.rate, output=True
+                )
+
+                wf = wave.open(f"{args.output}.wav", "wb")
+                wf.setnchannels(args.channels)
+                wf.setsampwidth(p.get_sample_size(audio_format))
+                wf.setframerate(args.rate)
+
+                stream_stopped_flag = False
+
+                try:
+                    for chunk in response.iter_content(chunk_size=1024):
+                        if chunk:
+                            stream.write(chunk)
+                            wf.writeframesraw(chunk)
+                        else:
+                            if not stream_stopped_flag:
+                                stream.stop_stream()
+                                stream_stopped_flag = True
+                finally:
+                    stream.close()
+                    p.terminate()
+                    wf.close()
         else:
             audio_content = response.content
             audio_path = f"{args.output}.{args.format}"

--- a/tools/api_client.py
+++ b/tools/api_client.py
@@ -215,7 +215,10 @@ if __name__ == "__main__":
                 p = pyaudio.PyAudio()
                 audio_format = pyaudio.paInt16  # Assuming 16-bit PCM format
                 stream = p.open(
-                    format=audio_format, channels=args.channels, rate=args.rate, output=True
+                    format=audio_format,
+                    channels=args.channels,
+                    rate=args.rate,
+                    output=True,
                 )
 
                 wf = wave.open(f"{args.output}.wav", "wb")


### PR DESCRIPTION
## Problem

`pyaudio` is currently a hard dependency in `pyproject.toml`, but it requires PortAudio system headers (`portaudio19-dev`) to build. This causes `pip install fish-speech` to fail on slim/headless containers (e.g., Docker, CI, server-only deployments) where PortAudio is not available.

Fixes #1304

## Solution

1. **`pyproject.toml`**: Moved `pyaudio` from `dependencies` to a new `[audio]` optional extra. Users who need interactive audio playback can install with `pip install fish-speech[audio]`.

2. **`tools/api_client.py`**: Replaced the top-level `import pyaudio` with a lazy import inside the streaming playback block. When `pyaudio` is not installed:
   - Prints a helpful message explaining how to install it
   - Falls back to saving the streamed audio to a `.wav` file instead of crashing
   - Non-streaming mode is completely unaffected

3. **`docs/en/install.md`**: Added documentation for headless installs and the new `[audio]` extra.

## Impact

- **Headless/server installs**: `pip install fish-speech` now succeeds without PortAudio
- **Interactive users**: `pip install fish-speech[audio]` restores full functionality
- **No breaking changes**: The API server and WebUI do not use `pyaudio` — only the interactive `api_client.py` tool does

## Testing

- Verified `python3 -m py_compile tools/api_client.py` passes
- Confirmed `pyaudio` is no longer a top-level import (checked via AST analysis)
- Verified the fallback path saves audio to file when `pyaudio` is missing

## Files changed

- `pyproject.toml` — moved pyaudio to optional `[audio]` extra
- `tools/api_client.py` — lazy import with graceful fallback
- `docs/en/install.md` — documented headless install option