### PR TITLE
feat: add FunASR dataset annotation tool

### DIFF
--- a/docs/en/finetune.md
+++ b/docs/en/finetune.md
@@ -27,6 +27,26 @@ You need to convert your dataset into the above format and place it under `data`
 !!! info
     The `.lab` annotation file only needs to contain the transcription of the audio, with no special formatting required. For example, if `hi.mp3` says "Hello, goodbye," then the `hi.lab` file would contain a single line of text: "Hello, goodbye."
 
+If your audio does not have transcripts yet, you can optionally create `.lab`
+files with FunASR and the default SenseVoiceSmall model:
+
+```bash
+pip install "funasr>=1.3.27,<2"
+python tools/annotate_funasr.py data --device cuda:0 --language auto
+```
+
+Use `--device cpu` on a machine without CUDA. The command searches `.wav`,
+`.mp3`, and `.flac` files recursively, skips existing `.lab` files by default,
+and continues when an individual audio file fails. Run it with `--dry-run` to
+preview the work or `--overwrite` to replace existing labels. `--model`,
+`--language`, and `--no-itn` can be used to select another FunASR checkpoint or
+change its transcription options.
+
+The default SenseVoiceSmall checkpoint supports Mandarin, Cantonese, English,
+Japanese, and Korean. Review generated labels before training, especially for
+long recordings or audio outside those languages. The checkpoint is distributed
+under the [FunASR Model License](https://github.com/modelscope/FunASR/blob/main/MODEL_LICENSE).
+
 !!! warning
     It's recommended to apply loudness normalization to the dataset. You can use [fish-audio-preprocess](https://github.com/fishaudio/audio-preprocess) to do this.
 

--- a/docs/zh/finetune.md
+++ b/docs/zh/finetune.md
@@ -26,6 +26,24 @@
 !!! info
     标注文件 `.lab` 仅需包含音频的转写文本，无需遵循特殊格式要求。例如，如果 `hi.mp3` 中的内容是“你好，再见。”，那么 `hi.lab` 文件中只需包含一行文本：“你好，再见”。    
 
+如果音频还没有转写文本，可以选择使用 FunASR 和默认的
+SenseVoiceSmall 模型生成 `.lab` 文件：
+
+```bash
+pip install "funasr>=1.3.27,<2"
+python tools/annotate_funasr.py data --device cuda:0 --language auto
+```
+
+没有 CUDA 时可改用 `--device cpu`。该命令会递归查找 `.wav`、`.mp3` 和
+`.flac` 文件，默认跳过已有的 `.lab` 文件，并在单个音频失败时继续处理。
+使用 `--dry-run` 可以先预览待处理文件，使用 `--overwrite` 可以覆盖已有标注。
+还可以通过 `--model`、`--language` 和 `--no-itn` 选择其他 FunASR 模型或
+调整转写选项。
+
+默认 SenseVoiceSmall 模型支持普通话、粤语、英语、日语和韩语。训练前请人工
+检查自动生成的标注，特别是长音频或上述语种之外的音频。该模型使用
+[FunASR 模型许可协议](https://github.com/modelscope/FunASR/blob/main/MODEL_LICENSE)。
+
 !!! warning
     建议先对数据集进行响度匹配, 你可以使用 [fish-audio-preprocess](https://github.com/fishaudio/audio-preprocess) 来完成这一步骤. 
     ```bash

--- a/tests/test_annotate_funasr.py
+++ b/tests/test_annotate_funasr.py
@@ -1,0 +1,160 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "annotate_funasr.py"
+
+
+def load_module():
+    if not MODULE_PATH.is_file():
+        raise AssertionError("FunASR annotation tool is not implemented")
+    spec = importlib.util.spec_from_file_location("annotate_funasr", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    if spec.loader is None:
+        raise AssertionError("Unable to load FunASR annotation tool")
+    spec.loader.exec_module(module)
+    return module
+
+
+def touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"audio")
+    return path
+
+
+class AnnotateFunASRTests(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def test_discovers_supported_audio_recursively_in_stable_order(self):
+        expected = [
+            touch(self.root / "a" / "first.WAV"),
+            touch(self.root / "a" / "second.mp3"),
+            touch(self.root / "b.flac"),
+        ]
+        touch(self.root / "ignored.ogg")
+        touch(self.root / "note.txt")
+
+        self.assertEqual(self.module.discover_audio_files(self.root), expected)
+
+    def test_skips_existing_labels_without_loading_the_transcriber(self):
+        audio = touch(self.root / "sample.wav")
+        audio.with_suffix(".lab").write_text("curated text", encoding="utf-8")
+
+        def must_not_run(_path):
+            raise AssertionError("transcriber should stay lazy")
+
+        stats = self.module.annotate_dataset(self.root, must_not_run)
+
+        self.assertEqual(stats, self.module.AnnotationStats(discovered=1, skipped=1))
+        self.assertEqual(
+            audio.with_suffix(".lab").read_text(encoding="utf-8"), "curated text"
+        )
+
+    def test_dry_run_reports_work_without_loading_or_writing(self):
+        audio = touch(self.root / "sample.mp3")
+
+        def must_not_run(_path):
+            raise AssertionError("transcriber should stay lazy")
+
+        stats = self.module.annotate_dataset(self.root, must_not_run, dry_run=True)
+
+        self.assertEqual(stats, self.module.AnnotationStats(discovered=1, planned=1))
+        self.assertFalse(audio.with_suffix(".lab").exists())
+
+    def test_writes_utf8_transcript_and_preserves_a_terminal_newline(self):
+        audio = touch(self.root / "speaker" / "sample.flac")
+
+        stats = self.module.annotate_dataset(
+            self.root, lambda _path: "  你好，世界。  "
+        )
+
+        self.assertEqual(stats, self.module.AnnotationStats(discovered=1, processed=1))
+        self.assertEqual(
+            audio.with_suffix(".lab").read_bytes(), "你好，世界。\n".encode()
+        )
+
+    def test_normalizes_transcript_whitespace_to_one_line(self):
+        audio = touch(self.root / "sample.wav")
+
+        stats = self.module.annotate_dataset(
+            self.root, lambda _path: "  first line\n\nsecond\tline  "
+        )
+
+        self.assertEqual(stats, self.module.AnnotationStats(discovered=1, processed=1))
+        self.assertEqual(
+            audio.with_suffix(".lab").read_text(encoding="utf-8"),
+            "first line second line\n",
+        )
+
+    def test_overwrite_replaces_an_existing_label(self):
+        audio = touch(self.root / "sample.wav")
+        label = audio.with_suffix(".lab")
+        label.write_text("old\n", encoding="utf-8")
+
+        stats = self.module.annotate_dataset(
+            self.root, lambda _path: "new", overwrite=True
+        )
+
+        self.assertEqual(stats, self.module.AnnotationStats(discovered=1, processed=1))
+        self.assertEqual(label.read_text(encoding="utf-8"), "new\n")
+
+    def test_one_failed_file_does_not_stop_the_remaining_dataset(self):
+        first = touch(self.root / "a.wav")
+        second = touch(self.root / "b.wav")
+        errors = []
+
+        def transcribe(path):
+            if path == first:
+                raise RuntimeError("damaged audio")
+            return "usable"
+
+        stats = self.module.annotate_dataset(
+            self.root,
+            transcribe,
+            on_error=lambda path, error: errors.append((path, str(error))),
+        )
+
+        self.assertEqual(
+            stats,
+            self.module.AnnotationStats(discovered=2, processed=1, failed=1),
+        )
+        self.assertEqual(errors, [(first, "damaged audio")])
+        self.assertFalse(first.with_suffix(".lab").exists())
+        self.assertEqual(
+            second.with_suffix(".lab").read_text(encoding="utf-8"), "usable\n"
+        )
+
+    def test_rejects_malformed_or_empty_funasr_results(self):
+        results = [
+            None,
+            [],
+            [{}],
+            [{"text": None}],
+            [{"text": ""}],
+            [{"text": "<|Speech|>"}],
+        ]
+        for result in results:
+            with self.subTest(result=result):
+                with self.assertRaisesRegex(ValueError, "transcription text"):
+                    self.module.extract_transcript(
+                        result, lambda text: text.replace("<|Speech|>", "")
+                    )
+
+    def test_extracts_and_postprocesses_funasr_text(self):
+        text = self.module.extract_transcript(
+            [{"text": "<|zh|><|NEUTRAL|><|Speech|>欢迎使用 Fish Speech"}],
+            lambda value: value.split(">", 3)[-1],
+        )
+
+        self.assertEqual(text, "欢迎使用 Fish Speech")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/annotate_funasr.py
+++ b/tools/annotate_funasr.py
@@ -1,0 +1,199 @@
+import os
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import click
+from loguru import logger
+
+AUDIO_EXTENSIONS = frozenset({".flac", ".mp3", ".wav"})
+
+
+@dataclass(frozen=True)
+class AnnotationStats:
+    discovered: int = 0
+    processed: int = 0
+    skipped: int = 0
+    failed: int = 0
+    planned: int = 0
+
+
+def discover_audio_files(dataset: Path) -> list[Path]:
+    files = (
+        path
+        for path in dataset.rglob("*")
+        if path.is_file() and path.suffix.lower() in AUDIO_EXTENSIONS
+    )
+    return sorted(
+        files, key=lambda path: path.relative_to(dataset).as_posix().casefold()
+    )
+
+
+def extract_transcript(result: Any, postprocess: Callable[[str], str]) -> str:
+    if not isinstance(result, list) or not result or not isinstance(result[0], dict):
+        raise ValueError("FunASR result did not contain transcription text")
+
+    raw_text = result[0].get("text")
+    if not isinstance(raw_text, str) or not raw_text.strip():
+        raise ValueError("FunASR result did not contain transcription text")
+
+    text = postprocess(raw_text).strip()
+    if not text:
+        raise ValueError("FunASR result did not contain transcription text")
+    return text
+
+
+def write_label(path: Path, text: str) -> None:
+    text = " ".join(text.split())
+    if not text:
+        raise ValueError("Refusing to write empty transcription text")
+
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            handle.write(f"{text}\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary_path.replace(path)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def annotate_dataset(
+    dataset: Path,
+    transcribe: Callable[[Path], str],
+    *,
+    overwrite: bool = False,
+    dry_run: bool = False,
+    on_error: Callable[[Path, Exception], None] | None = None,
+) -> AnnotationStats:
+    files = discover_audio_files(dataset)
+    processed = skipped = failed = planned = 0
+
+    if on_error is None:
+        on_error = lambda path, error: logger.error(
+            f"Failed to annotate {path}: {error}"
+        )
+
+    for audio_path in files:
+        label_path = audio_path.with_suffix(".lab")
+        if label_path.exists() and not overwrite:
+            skipped += 1
+            continue
+        if dry_run:
+            planned += 1
+            continue
+
+        try:
+            write_label(label_path, transcribe(audio_path))
+            processed += 1
+        except Exception as error:
+            failed += 1
+            on_error(audio_path, error)
+
+    return AnnotationStats(
+        discovered=len(files),
+        processed=processed,
+        skipped=skipped,
+        failed=failed,
+        planned=planned,
+    )
+
+
+class FunASRTranscriber:
+    def __init__(self, model: str, device: str, language: str, use_itn: bool):
+        self.model_name = model
+        self.device = device
+        self.language = language
+        self.use_itn = use_itn
+        self._model = None
+        self._postprocess = None
+        self._load_error = None
+
+    def _load(self) -> None:
+        if self._model is not None:
+            return
+        if self._load_error is not None:
+            raise self._load_error
+
+        try:
+            from funasr import AutoModel
+            from funasr.utils.postprocess_utils import rich_transcription_postprocess
+        except ImportError as error:
+            self._load_error = RuntimeError(
+                "FunASR is required for annotation. Install it with "
+                "`pip install 'funasr>=1.3.27,<2'`."
+            )
+            raise self._load_error from error
+
+        self._model = AutoModel(
+            model=self.model_name,
+            device=self.device,
+            disable_update=True,
+        )
+        self._postprocess = rich_transcription_postprocess
+
+    def __call__(self, audio_path: Path) -> str:
+        self._load()
+        result = self._model.generate(
+            input=str(audio_path),
+            cache={},
+            language=self.language,
+            use_itn=self.use_itn,
+        )
+        return extract_transcript(result, self._postprocess)
+
+
+@click.command()
+@click.argument(
+    "dataset",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option("--model", default="iic/SenseVoiceSmall", show_default=True)
+@click.option("--device", default="cuda:0", show_default=True)
+@click.option("--language", default="auto", show_default=True)
+@click.option("--itn/--no-itn", default=True, show_default=True)
+@click.option("--overwrite", is_flag=True, help="Replace existing .lab files.")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Report files that would be annotated without loading a model.",
+)
+def main(
+    dataset: Path,
+    model: str,
+    device: str,
+    language: str,
+    itn: bool,
+    overwrite: bool,
+    dry_run: bool,
+) -> None:
+    transcriber = FunASRTranscriber(model, device, language, itn)
+    stats = annotate_dataset(
+        dataset,
+        transcriber,
+        overwrite=overwrite,
+        dry_run=dry_run,
+    )
+    click.echo(
+        "Annotation summary: "
+        f"discovered={stats.discovered}, processed={stats.processed}, "
+        f"skipped={stats.skipped}, failed={stats.failed}, planned={stats.planned}"
+    )
+    if stats.failed:
+        raise click.exceptions.Exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Closes #1291 by adding an optional FunASR dataset annotation CLI that creates Fish Speech `.lab` files recursively from WAV, MP3, and FLAC audio.

## Changes

- Keeps existing labels by default; supports explicit dry-run and overwrite modes.
- Writes normalized one-line UTF-8 labels atomically and isolates individual file failures.
- Lazy-loads FunASR outside the core dependency surface; documents CPU/CUDA usage in English and Chinese.
- Defaults to SenseVoiceSmall, with configurable model, device, language, and ITN.

The branch now includes upstream main `214da3cd841bda85da2496b96cd3c4d7edb1337e`, preserving history with a merge. Its diff against that main remains four files, 397 insertions. No core dependency or training behavior changes are introduced by this PR.

## Current Validation

Validated 2026-09-22 on the exact tree published as `3566c550b59f65d48934064bfa7ae49740854bb9`:

- `python -m unittest discover -s tests -p test_annotate_funasr.py -v`: **9 passed**. Covers label preservation, explicit overwrite, dry-run, deterministic discovery, malformed output, one-line formatting, and per-file failure isolation.
- Current repository pre-commit hooks passed on all four PR files: isort 9.0.0b1, Black 26.5.1, EOF, mixed line endings, and large-file checks. YAML/JSON checks had no applicable files.
- CLI `--help` and `--dry-run` passed in an isolated Python 3.12.3 environment with Click 8.4.1 and Loguru 0.7.3, **without FunASR installed or imported**. The dry-run preserved an existing label and created no new label.
- Both PR Python files compile; staged `git diff --check` passed.
- `uv pip check` passed for the 12-package focused test/tool environment. This is not validation of the full Fish Speech training environment.
- The four PR files are unchanged from the previously published integration; the merge incorporates current upstream changes. The new commit is signed and includes DCO sign-off.

The full repository suite, training, current-head model inference, and GPU execution were not run in this validation. The earlier H100 Chinese/English SenseVoice smoke and full-environment claims in the discussion are historical, not acceptance evidence for this new head. Maintainer review is still pending.
