### PR TITLE
perf(text2semantic): pass only active KV cache prefix to SDPA

### DIFF
--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -104,12 +104,14 @@ def decode_one_token_ar(
     audio_masks: torch.Tensor,
     audio_parts: torch.Tensor,
     previous_tokens: Optional[torch.Tensor] = None,
+    kv_len: Optional[int] = None,
 ) -> torch.Tensor:
     forward_result = model.forward_generate(
         x,
         input_pos,
         audio_masks=audio_masks,
         audio_parts=audio_parts,
+        kv_len=kv_len,
     )
     logits = forward_result.logits  # (1, 1, vocab_size)
     hidden_states = forward_result.hidden_states
@@ -193,7 +195,13 @@ def decode_n_tokens(
     audio_masks: torch.Tensor,
     audio_parts: torch.Tensor,
     decode_one_token=decode_one_token_ar,
+    kv_start_pos: Optional[int] = None,
 ):
+    if kv_start_pos is None:
+        # Compatibility fallback for direct callers. The production generation
+        # path passes the Python position explicitly to avoid a device sync.
+        kv_start_pos = int(input_pos[0].item())
+
     # Rolling window for RAS (Repetition Aware Sampling)
     previous_tokens = torch.zeros(
         (model.config.num_codebooks + 1, RAS_WIN_SIZE),
@@ -212,6 +220,7 @@ def decode_n_tokens(
                 model=model,
                 x=cur_token,
                 input_pos=input_pos,
+                kv_len=kv_start_pos + i + 1,
                 previous_tokens=previous_tokens,
                 temperature=temperature,
                 top_p=top_p,
@@ -331,6 +340,7 @@ def generate(
         semantic_logit_bias,
         audio_masks,
         audio_parts,
+        kv_len=T,
     )
     seq[:, T : T + 1] = first_token
 
@@ -349,6 +359,7 @@ def generate(
         audio_masks=audio_masks,
         audio_parts=audio_parts,
         decode_one_token=decode_one_token,
+        kv_start_pos=T,
     )
     seq = seq[:, : T + 1 + x.size(1)]
     seq[:, T + 1 :] = x

--- a/fish_speech/models/text2semantic/llama.py
+++ b/fish_speech/models/text2semantic/llama.py
@@ -394,6 +394,7 @@ class BaseTransformer(nn.Module):
         audio_masks: Optional[Tensor] = None,
         audio_parts: Optional[Tensor] = None,
         return_all: bool = False,
+        kv_len: Optional[int] = None,
     ) -> BaseTransformerForwardResult:
 
         # Embedding logic replicated from embed() for compilation compatibility
@@ -432,13 +433,23 @@ class BaseTransformer(nn.Module):
             else:
                 logger.warning("audio_parts provided but model has no audio_projector")
 
+        cache_capacity = (
+            self.max_seq_len if self.max_seq_len > 0 else self.config.max_seq_len
+        )
         if input_pos is None:
             input_pos = torch.arange(inp.shape[-1], device=x.device)
-            max_seq_len = inp.shape[-1]
+            active_kv_len = inp.shape[-1]
         else:
-            max_seq_len = self.max_seq_len
+            active_kv_len = cache_capacity if kv_len is None else kv_len
 
-        mask = self.causal_mask[None, None, input_pos, :max_seq_len]  # (B, N, Q, K)
+        if not 1 <= active_kv_len <= cache_capacity:
+            raise ValueError(
+                f"kv_len must be between 1 and {cache_capacity}, got {active_kv_len}"
+            )
+
+        mask = self.causal_mask[
+            None, None, input_pos, :active_kv_len
+        ]  # (B, N, Q, active K)
         freqs_cis = self.freqs_cis[input_pos]
 
         for layer in self.layers:
@@ -651,9 +662,12 @@ class NaiveTransformer(BaseTransformer):
         return self.decode(result)
 
     def forward_generate(
-        self, x: Tensor, input_pos: Optional[Tensor] = None
+        self,
+        x: Tensor,
+        input_pos: Optional[Tensor] = None,
+        kv_len: Optional[int] = None,
     ) -> TransformerForwardResult:
-        result = super().forward_generate(x, input_pos)
+        result = super().forward_generate(x, input_pos, kv_len=kv_len)
         return self.decode(result)
 
 
@@ -822,8 +836,15 @@ class DualARTransformer(BaseTransformer):
         input_pos: Optional[Tensor] = None,
         audio_masks: Optional[Tensor] = None,
         audio_parts: Optional[Tensor] = None,
+        kv_len: Optional[int] = None,
     ) -> TransformerForwardResult:
-        x = super().forward_generate(x, input_pos, audio_masks, audio_parts)
+        x = super().forward_generate(
+            x,
+            input_pos,
+            audio_masks,
+            audio_parts,
+            kv_len=kv_len,
+        )
         x.hidden_states = self.fast_project_in(x.hidden_states)
         return x
 
@@ -909,6 +930,12 @@ class Attention(nn.Module):
 
         if self.kv_cache is not None:
             k, v = self.kv_cache.update(input_pos, k, v)
+            if mask is not None:
+                # Keep the cache allocated at max_seq_len, but repeat and
+                # attend only to the prefix populated so far.
+                active_kv_len = mask.shape[-1]
+                k = k[:, :, :active_kv_len]
+                v = v[:, :, :active_kv_len]
 
         k = k.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
         v = v.repeat_interleave(self.n_head // self.n_local_heads, dim=1)

--- a/tests/test_active_kv_attention.py
+++ b/tests/test_active_kv_attention.py
@@ -1,0 +1,331 @@
+import copy
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch.nn import functional as F
+
+from fish_speech.models.text2semantic.inference import generate
+from fish_speech.models.text2semantic.llama import (
+    Attention,
+    BaseModelArgs,
+    DualARModelArgs,
+    DualARTransformer,
+    KVCache,
+    NaiveModelArgs,
+    NaiveTransformer,
+    precompute_freqs_cis,
+)
+
+CACHE_CAPACITY = 8
+PROMPT_LENGTH = 3
+
+
+class _TokenizerStub:
+    eos_token_id = 15
+
+    def get_token_id(self, _token: str) -> int:
+        return self.eos_token_id
+
+
+def _base_args(**overrides) -> dict:
+    args = {
+        "vocab_size": 16,
+        "n_layer": 1,
+        "n_head": 2,
+        "n_local_heads": 1,
+        "dim": 8,
+        "intermediate_size": 16,
+        "head_dim": 4,
+        "max_seq_len": CACHE_CAPACITY,
+        "dropout": 0.0,
+        "tie_word_embeddings": False,
+        "codebook_size": 8,
+        "num_codebooks": 2,
+        "semantic_begin_id": 4,
+        "semantic_end_id": 11,
+        "use_gradient_checkpointing": False,
+    }
+    args.update(overrides)
+    return args
+
+
+class ActiveKVAttentionTest(unittest.TestCase):
+    @staticmethod
+    def _attention() -> Attention:
+        config = BaseModelArgs(**_base_args())
+        attention = Attention(config).eval()
+        attention.kv_cache = KVCache(
+            max_batch_size=1,
+            max_seq_len=CACHE_CAPACITY,
+            n_heads=1,
+            head_dim=4,
+            dtype=torch.float32,
+        )
+        return attention
+
+    @staticmethod
+    def _seed_cache(attention: Attention) -> None:
+        torch.manual_seed(100)
+        attention.kv_cache.k_cache[:, :, :2] = torch.randn(1, 1, 2, 4)
+        attention.kv_cache.v_cache[:, :, :2] = torch.randn(1, 1, 2, 4)
+
+    def test_attention_passes_only_active_kv_prefix_to_sdpa(self) -> None:
+        torch.manual_seed(1)
+        attention = self._attention()
+        self._seed_cache(attention)
+        x = torch.randn(1, 1, 8)
+        freqs_cis = precompute_freqs_cis(CACHE_CAPACITY, 4)[2:3]
+        mask = torch.ones(1, 1, 1, 3, dtype=torch.bool)
+        original_sdpa = F.scaled_dot_product_attention
+        observed_shapes = []
+
+        def capture_sdpa(query, key, value, **kwargs):
+            observed_shapes.append((key.shape, value.shape))
+            return original_sdpa(query, key, value, **kwargs)
+
+        with patch(
+            "fish_speech.models.text2semantic.llama.F.scaled_dot_product_attention",
+            side_effect=capture_sdpa,
+        ):
+            attention(x, freqs_cis, mask, input_pos=torch.tensor([2]))
+
+        self.assertEqual(
+            observed_shapes,
+            [(torch.Size([1, 2, 3, 4]), torch.Size([1, 2, 3, 4]))],
+        )
+        self.assertEqual(attention.kv_cache.k_cache.shape[2], CACHE_CAPACITY)
+
+    def test_active_prefix_matches_masked_full_cache_with_tolerance(self) -> None:
+        torch.manual_seed(2)
+        active_attention = self._attention()
+        self._seed_cache(active_attention)
+        full_attention = copy.deepcopy(active_attention)
+        x = torch.randn(1, 1, 8)
+        freqs_cis = precompute_freqs_cis(CACHE_CAPACITY, 4)[2:3]
+        active_mask = torch.ones(1, 1, 1, 3, dtype=torch.bool)
+        full_mask = torch.zeros(1, 1, 1, CACHE_CAPACITY, dtype=torch.bool)
+        full_mask[..., :3] = True
+        input_pos = torch.tensor([2])
+
+        active_output = active_attention(
+            x,
+            freqs_cis,
+            active_mask,
+            input_pos=input_pos,
+        )
+        full_output = full_attention(
+            x,
+            freqs_cis,
+            full_mask,
+            input_pos=input_pos,
+        )
+
+        torch.testing.assert_close(active_output, full_output, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(
+            active_output.argmax(dim=-1),
+            full_output.argmax(dim=-1),
+            rtol=0,
+            atol=0,
+        )
+
+
+class ActiveKVProgressionTest(unittest.TestCase):
+    @staticmethod
+    def _model() -> NaiveTransformer:
+        torch.manual_seed(3)
+        model = NaiveTransformer(NaiveModelArgs(**_base_args())).eval()
+        model.setup_caches(1, CACHE_CAPACITY, dtype=torch.float32)
+        return model
+
+    @staticmethod
+    def _tokens(length: int) -> torch.Tensor:
+        main = torch.arange(1, length + 1).remainder(4).view(1, 1, length)
+        codebooks = torch.arange(2 * length).remainder(8).view(1, 2, length)
+        return torch.cat((main, codebooks), dim=1)
+
+    def test_kv_len_validation(self) -> None:
+        model = self._model()
+        token = self._tokens(1)
+        input_pos = torch.tensor([0])
+
+        minimum_prefix = model.forward_generate(
+            token,
+            input_pos=input_pos,
+            kv_len=1,
+        )
+        self.assertTrue(torch.isfinite(minimum_prefix.token_logits).all())
+        self.assertTrue(torch.isfinite(minimum_prefix.codebook_logits).all())
+
+        for invalid_kv_len in (0, CACHE_CAPACITY + 1):
+            with self.subTest(kv_len=invalid_kv_len):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    f"kv_len must be between 1 and {CACHE_CAPACITY}",
+                ):
+                    model.forward_generate(
+                        token,
+                        input_pos=input_pos,
+                        kv_len=invalid_kv_len,
+                    )
+
+    def test_prefill_first_decode_and_maximum_prefix(self) -> None:
+        model = self._model()
+        original_sdpa = F.scaled_dot_product_attention
+        observed_k_lengths = []
+
+        def capture_sdpa(query, key, value, **kwargs):
+            observed_k_lengths.append(
+                (key.shape[-2], value.shape[-2], kwargs["attn_mask"].shape[-1])
+            )
+            return original_sdpa(query, key, value, **kwargs)
+
+        with patch(
+            "fish_speech.models.text2semantic.llama.F.scaled_dot_product_attention",
+            side_effect=capture_sdpa,
+        ):
+            prefill = model.forward_generate(
+                self._tokens(PROMPT_LENGTH),
+                input_pos=torch.arange(PROMPT_LENGTH),
+                kv_len=PROMPT_LENGTH,
+            )
+            first_decode = model.forward_generate(
+                self._tokens(1),
+                input_pos=torch.tensor([PROMPT_LENGTH]),
+                kv_len=PROMPT_LENGTH + 1,
+            )
+            maximum_prefix = model.forward_generate(
+                self._tokens(1),
+                input_pos=torch.tensor([CACHE_CAPACITY - 1]),
+                kv_len=CACHE_CAPACITY,
+            )
+
+        self.assertEqual(
+            observed_k_lengths,
+            [
+                (PROMPT_LENGTH, PROMPT_LENGTH, PROMPT_LENGTH),
+                (PROMPT_LENGTH + 1, PROMPT_LENGTH + 1, PROMPT_LENGTH + 1),
+                (CACHE_CAPACITY, CACHE_CAPACITY, CACHE_CAPACITY),
+            ],
+        )
+        for result in (prefill, first_decode, maximum_prefix):
+            self.assertTrue(torch.isfinite(result.token_logits).all())
+            self.assertTrue(torch.isfinite(result.codebook_logits).all())
+
+
+class ActiveKVAutoregressiveDecodeTest(unittest.TestCase):
+    @staticmethod
+    def _model() -> DualARTransformer:
+        torch.manual_seed(4)
+        config = DualARModelArgs(
+            **_base_args(
+                n_fast_layer=1,
+                fast_dim=8,
+                fast_n_head=2,
+                fast_n_local_heads=1,
+                fast_head_dim=4,
+                fast_intermediate_size=16,
+            )
+        )
+        model = DualARTransformer(config).eval()
+        model.tokenizer = _TokenizerStub()
+        return model
+
+    @staticmethod
+    def _prompt() -> torch.Tensor:
+        return torch.tensor(
+            [
+                [1, 2, 3],
+                [0, 1, 2],
+                [3, 4, 5],
+            ],
+            dtype=torch.long,
+        )
+
+    @staticmethod
+    def _run_generation(model, *, use_active_prefix):
+        slow_logits = []
+        fast_logits = []
+        observed_kv_lengths = []
+        original_forward = model.forward_generate
+        original_fast_forward = model.forward_generate_fast
+
+        def capture_forward(*args, **kwargs):
+            observed_kv_lengths.append(kwargs.get("kv_len"))
+            if not use_active_prefix:
+                kwargs["kv_len"] = None
+            result = original_forward(*args, **kwargs)
+            result.logits[..., model.tokenizer.eos_token_id] = -1e9
+            slow_logits.append(result.logits.detach().clone())
+            return result
+
+        def capture_fast_forward(*args, **kwargs):
+            logits = original_fast_forward(*args, **kwargs)
+            fast_logits.append(logits.detach().clone())
+            return logits
+
+        with (
+            patch.object(model, "forward_generate", side_effect=capture_forward),
+            patch.object(
+                model,
+                "forward_generate_fast",
+                side_effect=capture_fast_forward,
+            ),
+            patch(
+                "fish_speech.models.text2semantic.inference.tqdm",
+                side_effect=lambda values, **_kwargs: values,
+            ),
+        ):
+            output = generate(
+                model=model,
+                prompt=ActiveKVAutoregressiveDecodeTest._prompt(),
+                max_new_tokens=3,
+                audio_masks=None,
+                audio_parts=None,
+                temperature=0.8,
+                top_p=0.8,
+                top_k=1,
+            )
+
+        return output, slow_logits, fast_logits, observed_kv_lengths
+
+    def test_real_decode_chain_preserves_greedy_tokens_and_distributions(self) -> None:
+        active_model = self._model()
+        full_cache_model = copy.deepcopy(active_model)
+
+        torch.manual_seed(5)
+        active = self._run_generation(active_model, use_active_prefix=True)
+        torch.manual_seed(5)
+        full = self._run_generation(full_cache_model, use_active_prefix=False)
+        active_output, active_slow, active_fast, active_kv_lengths = active
+        full_output, full_slow, full_fast, full_kv_lengths = full
+
+        expected_shape = (1 + active_model.config.num_codebooks, PROMPT_LENGTH + 3)
+        self.assertEqual(active_output.shape, expected_shape)
+        self.assertEqual(full_output.shape, expected_shape)
+        self.assertEqual(active_kv_lengths, [PROMPT_LENGTH, 4, 5])
+        self.assertEqual(full_kv_lengths, active_kv_lengths)
+
+        self.assertEqual(len(active_slow), len(full_slow))
+        self.assertEqual(len(active_fast), len(full_fast))
+        for active_logits, full_logits in zip(
+            active_slow + active_fast,
+            full_slow + full_fast,
+        ):
+            self.assertTrue(torch.isfinite(active_logits).all())
+            self.assertTrue(torch.isfinite(full_logits).all())
+            active_probs = torch.softmax(active_logits, dim=-1)
+            full_probs = torch.softmax(full_logits, dim=-1)
+            torch.testing.assert_close(active_probs, full_probs, rtol=1e-5, atol=1e-6)
+            torch.testing.assert_close(
+                active_probs.argmax(dim=-1),
+                full_probs.argmax(dim=-1),
+                rtol=0,
+                atol=0,
+            )
+
+        torch.testing.assert_close(active_output, full_output, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Performance optimization for the native PyTorch autoregressive inference path.

### Problem

During cached generation, the physical KV cache is preallocated at
`max_seq_len`. At every decode step, the current implementation expands the
full-capacity K/V tensors with `repeat_interleave` and passes the full K/V
sequence to SDPA. For S2-Pro, this means expanding and passing a key sequence
length of 32768 to SDPA even when only a few hundred positions have been
populated.

This describes the tensors supplied to SDPA; it does not assume how a
particular SDPA backend handles the masked, unpopulated tail internally.

### Change

This change keeps the physical KV cache at full capacity but limits attention
to the active prefix:

- prompt prefill uses `kv_len=T`;
- decode step `i` uses `kv_len=T+i+1`;
- the causal mask is sliced to the active K length;
- cached K/V are sliced before head expansion and SDPA.

The regular full-sequence `forward()` path used for training does not use the
inference KV cache and is unchanged. The new slicing is gated by
`self.kv_cache is not None` and is exercised by cached `forward_generate()`
inference.

### Benchmark results

S2-Pro, FP16, native PyTorch CLI inference, prompt length 234,
`max_seq_len=32768`. Throughput is the median of three warm samples:

| Mode | Full-capacity KV | Active-prefix KV | Speedup | Peak CUDA memory reserved (GB) |
|---|---:|---:|---:|---:|
| Eager | 2.73 tok/s | 12.57 tok/s | **4.60x** | 17.33 -> 15.16 |
| `torch.compile` | 16.65 tok/s | 32.74 tok/s | **1.97x** | 15.72 -> 15.16 |

CUDA environment: Quadro GV100 32 GB, PyTorch 2.8.0+cu128, Triton 3.4.0.

Generated lengths differed slightly because FP16/kernel differences can change
stochastic sampling trajectories, so throughput is normalized by the number of
generated tokens.

The memory values are decimal GB, matching the existing log calculation
`torch.cuda.max_memory_reserved() / 1e9`.

The same change was also validated on Apple MPS (M4 Pro 48 GB, FP16,
`max_seq_len=4096`), where semantic generation improved from 4.08 to
8.31 frames/s (**2.04x**). The MPS service metric and CUDA CLI tok/s are not
directly comparable; only their within-device A/B ratios are reported.

Cold compile time is excluded from the throughput comparison. The existing
`Bandwidth achieved` log value is also excluded because it is derived from
model size and tok/s rather than measured hardware DRAM bandwidth.

### Correctness and compatibility validation

- Upstream pre-commit hooks pass for both modified files.
- A CPU shape check confirmed that SDPA receives only the active K/V prefix
  while the physical KV cache retains full capacity.
- A CPU float32 comparison confirmed that active-prefix attention matches
  full-cache attention with a masked tail (`rtol=1e-5`, `atol=1e-6`).
- CUDA eager and `torch.compile` generation completed successfully.
- With `TORCH_LOGS=recompiles`, the compiled active-KV path recompiled once
  when `kv_len` first changed, not once per token; warm throughput remained
  stable at approximately 32.7 tok/s.
- Four representative CUDA outputs (full/active x eager/compiled) were decoded
  and manually listened to; no audible regression was observed.
- MPS end-to-end generation and manual listening completed successfully.

The benchmark results above were collected from
[`c4146e7`](https://github.com/quantumxiaol/fish-speech/commit/c4146e7e0145e615c76c34ab1d54829fde1a06ed).
The current draft contains only the two production source changes; the
standalone correctness tests used for validation remain available in that
commit.

**Is this pull request related to any issue? If yes, please link the issue.**

Closes #1310
