### PR TITLE
fix: match the dac inference input suffix case-insensitively

### DIFF
--- a/fish_speech/models/dac/inference.py
+++ b/fish_speech/models/dac/inference.py
@@ -71,7 +71,8 @@ def load_model(config_name, checkpoint_path, device="cuda"):
 def main(input_path, output_path, config_name, checkpoint_path, device):
     model = load_model(config_name, checkpoint_path, device=device)
 
-    if input_path.suffix in AUDIO_EXTENSIONS:
+    suffix = input_path.suffix.lower()
+    if suffix in AUDIO_EXTENSIONS:
         logger.info(f"Processing in-place reconstruction of {input_path}")
 
         # Load audio
@@ -96,7 +97,7 @@ def main(input_path, output_path, config_name, checkpoint_path, device):
 
         # Save indices
         np.save(output_path.with_suffix(".npy"), indices.cpu().numpy())
-    elif input_path.suffix == ".npy":
+    elif suffix == ".npy":
         logger.info(f"Processing precomputed indices from {input_path}")
         indices = np.load(input_path)
         indices = torch.from_numpy(indices).to(device).long()


### PR DESCRIPTION
## Problem

`fish_speech/models/dac/inference.py` picks its branch from the raw suffix:

```python
if input_path.suffix in AUDIO_EXTENSIONS:      # encode audio -> .npy
elif input_path.suffix == ".npy":              # decode indices -> audio
else: raise ValueError(f"Unknown input type: {input_path}")
```

`Path.suffix` preserves case and `AUDIO_EXTENSIONS` is lowercase, so an audio file with an uppercase extension misses the first arm, misses the `.npy` arm too, and lands in the error:

| `--input-path` | current | with this change |
|---|---|---|
| `sample.wav` | encode audio | encode audio |
| `sample.WAV` | **ValueError: Unknown input type** | encode audio |
| `Sample.Wav` | **ValueError: Unknown input type** | encode audio |
| `clip.MP3` | **ValueError: Unknown input type** | encode audio |
| `tokens.npy` | decode indices | decode indices |
| `tokens.NPY` | **ValueError: Unknown input type** | decode indices |

`--input-path` is a user-supplied CLI argument and `click.Path(exists=True)` has already confirmed the file is there, so the message reads as though a real, readable wav is an unsupported format. Recorders, phones and camera firmware write uppercase extensions routinely.

## Fix

Lowercase the suffix once and compare against that, which is the pattern the codebase already uses in `fish_speech/inference_engine/reference_loader.py:218`:

```python
if audio_path.suffix.lower() not in AUDIO_EXTENSIONS:
```

Only the two comparisons change. `input_path` itself is untouched, so the file is still opened under its original name and log lines are unchanged.

## Verification

The branch is chosen purely by the suffix comparison, so it reproduces without a checkpoint or a GPU. The table above is the output of walking the same if/elif/else chain over those six filenames, before and after.

`black` and `isort` are clean on the changed file.

## Related

`fish_speech/utils/file.py:81` collects files with `path.rglob(f"*{ext}")` over the same lowercase set. `pathlib` glob matching follows the filesystem, so that call already finds `song.WAV` on Windows and macOS but skips it on Linux. That is a separate behavioural question about `list_files`, so I have left it out of this PR. Happy to open a second one if you would like it handled the same way.
