### PR TITLE
fix: load reference audio via soundfile on Windows (torchaudio>=2.9 TorchCodec fallback)

### DIFF
--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -144,7 +144,9 @@ class ReferenceLoader:
             # torchaudio>=2.9 ignores backend= and always decodes through
             # TorchCodec, which requires FFmpeg shared libraries that are
             # commonly missing on Windows.
-            waveform, original_sr = torchaudio.load(reference_audio, backend=self.backend)
+            waveform, original_sr = torchaudio.load(
+                reference_audio, backend=self.backend
+            )
         else:
             # soundfile bundles libsndfile, so it works without system FFmpeg.
             data, original_sr = sf.read(

--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -138,7 +138,19 @@ class ReferenceLoader:
             audio_data = reference_audio
             reference_audio = io.BytesIO(audio_data)
 
-        waveform, original_sr = torchaudio.load(reference_audio, backend=self.backend)
+        try:
+            import soundfile as sf
+        except ImportError:
+            # torchaudio>=2.9 ignores backend= and always decodes through
+            # TorchCodec, which requires FFmpeg shared libraries that are
+            # commonly missing on Windows.
+            waveform, original_sr = torchaudio.load(reference_audio, backend=self.backend)
+        else:
+            # soundfile bundles libsndfile, so it works without system FFmpeg.
+            data, original_sr = sf.read(
+                reference_audio, dtype="float32", always_2d=True
+            )
+            waveform = torch.from_numpy(data).transpose(0, 1).contiguous()
 
         if waveform.shape[0] > 1:
             waveform = torch.mean(waveform, dim=0, keepdim=True)


### PR DESCRIPTION
## Problem

On Windows, `/v1/tts` fails with a 500 on any request because `ReferenceLoader.load_audio` calls `torchaudio.load(reference_audio, backend=self.backend)`, and **torchaudio >= 2.9 ignores the `backend=` argument and always routes through TorchCodec** (the docstring states these params are kept 'only for backwards compatibility').

TorchCodec loads `libtorchcodec_core*.dll` via `ctypes`, which requires FFmpeg **shared** libraries (avcodec/avformat/swresample...). The common Windows install path (e.g. WinGet's `Gyan.FFmpeg` full/essentials builds, or a static ffmpeg) ships **no DLLs**, so the import crashes:

```
RuntimeError: Could not load libtorchcodec. ... ensure you've installed the full-shared version which ships DLLs.
```

The existing backend-selection logic (lines 36-52) can't help: even when it correctly picks `soundfile`, the backend parameter is discarded by `torchaudio.load`.

## Fix

In `load_audio`, prefer decoding via `soundfile` directly (its wheel bundles libsndfile, so it works with zero system dependencies) and keep `torchaudio.load` as the fallback for environments where TorchCodec is functional.

`soundfile` is already an install-time dependency via `librosa`, so no dependency changes are needed.

Verified end-to-end on Windows 11 / AMD RX 7700 XT: reference audio (WAV path and raw bytes) loads correctly, TTS produces valid output. Also confirmed the current `main` branch reproduces the failure before this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/fish-speech/pr/1316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788563523&installation_model_id=430858&pr_number=1316&repository=fishaudio%2Ffish-speech&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Ffish-speech%2Fpull%2F1316&signature=d13d924d4f005c75ee50bb482f47dc4d3865f4006bd6bcae924e409740285a02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->