### PR TITLE
fix: honor the `recursive` parameter in list_files()

### DIFF
--- a/fish_speech/utils/file.py
+++ b/fish_speech/utils/file.py
@@ -78,7 +78,8 @@ def list_files(
     if not path.exists():
         raise FileNotFoundError(f"Directory {path} does not exist.")
 
-    files = [file for ext in extensions for file in path.rglob(f"*{ext}")]
+    globber = path.rglob if recursive else path.glob
+    files = [file for ext in extensions for file in globber(f"*{ext}")]
 
     if sort:
         files = natsorted(files)


### PR DESCRIPTION
`list_files()` in `fish_speech/utils/file.py` accepts a `recursive` argument and documents it as *"Whether to search recursively. Defaults to False"*, but the implementation always called `Path.rglob()` — so the search was recursive no matter what the caller passed.

### Impact

`ReferenceLoader.list_reference_ids()` calls it with `recursive=False`, expecting to scan only the top level of each `references/<id>/` folder. Because the flag was ignored, a stray audio file in a nested subdirectory could make an otherwise-invalid reference ID appear valid.

The other two call sites (`tools/vqgan/create_train_split.py`, `tools/vqgan/extract_vq.py`) pass `recursive=True`, so their behavior is unchanged.

### Fix

Select `rglob`/`glob` based on the flag:

```python
globber = path.rglob if recursive else path.glob
files = [file for ext in extensions for file in globber(f"*{ext}")]
```

### Verification

Against a `demo/` tree containing `top.wav` and `sub/nested.wav`:

| call | before | after |
|---|---|---|
| `recursive=False` | `top.wav`, `sub/nested.wav` | `top.wav` |
| `recursive=True` | `top.wav`, `sub/nested.wav` | `top.wav`, `sub/nested.wav` |

The repo has no test suite, so I kept this to the one-line behavioral fix rather than introducing pytest as a new dependency.

