### PR TITLE
fix: dispatch on type instead of length in ReferenceLoader.load_audio()

### DIFF
--- a/fish_speech/inference_engine/reference_loader.py
+++ b/fish_speech/inference_engine/reference_loader.py
@@ -134,9 +134,8 @@ class ReferenceLoader:
         """
         Load the audio data from a file or bytes.
         """
-        if len(reference_audio) > 255 or not Path(reference_audio).exists():
-            audio_data = reference_audio
-            reference_audio = io.BytesIO(audio_data)
+        if isinstance(reference_audio, bytes):
+            reference_audio = io.BytesIO(reference_audio)
 
         waveform, original_sr = torchaudio.load(reference_audio, backend=self.backend)
 


### PR DESCRIPTION
`ReferenceLoader.load_audio()` accepts `bytes | str` and uses `len(reference_audio) > 255` as a proxy for *"this is raw audio rather than a path"*. That heuristic is wrong in three of the four possible cases.

### Current behavior

| input | result |
|---|---|
| bytes shorter than 256 (truncated/empty upload) | ❌ `TypeError: argument should be a str object or an os.PathLike object returning str, not <class 'bytes'>` |
| bytes longer than 255 (normal audio) | ✅ works |
| str path that does not exist | ❌ `TypeError: a bytes-like object is required, not 'str'` |
| valid str path longer than 255 chars | ❌ misread as audio data → same `TypeError` |

Only the common "long bytes" case behaves as intended. Short byte strings fall through to `Path(bytes)`, and any `str` that fails the `.exists()` check reaches `io.BytesIO(str)` — neither accepts the type it is handed.

### Impact

Both production callers reach this through `VQManager.encode_reference()` with **bytes** — `audio_to_bytes()` for id-based references, and `ServeReferenceAudio.audio` for API requests. So a small or malformed upload surfaces an opaque `TypeError` about `os.PathLike` rather than a meaningful decode error.

### Fix

```python
if isinstance(reference_audio, bytes):
    reference_audio = io.BytesIO(reference_audio)
```

Dispatch on the actual type and let `torchaudio.load()` report missing or undecodable files — it already does so with a clear message. This fixes all three broken cases and leaves the working one unchanged.

The repo has no test suite, so I kept this to the behavioral fix rather than introducing pytest as a new dependency.

