### PR TITLE
fix: validate reference arguments in api_client instead of failing silently

### DIFF
--- a/tools/api_client.py
+++ b/tools/api_client.py
@@ -143,16 +143,23 @@ if __name__ == "__main__":
     idstr: str | None = args.reference_id
     # priority: ref_id > [{text, audio},...]
     if idstr is None:
-        ref_audios = args.reference_audio
-        ref_texts = args.reference_text
-        if ref_audios is None:
-            byte_audios = []
-        else:
-            byte_audios = [audio_to_bytes(ref_audio) for ref_audio in ref_audios]
-        if ref_texts is None:
-            ref_texts = []
-        else:
-            ref_texts = [read_ref_text(ref_text) for ref_text in ref_texts]
+        ref_audios = args.reference_audio or []
+        ref_texts = args.reference_text or []
+
+        if len(ref_audios) != len(ref_texts):
+            raise SystemExit(
+                "--reference_audio and --reference_text must be given the same number "
+                f"of values, got {len(ref_audios)} audio(s) and {len(ref_texts)} text(s)."
+            )
+
+        byte_audios = []
+        for ref_audio in ref_audios:
+            audio_bytes = audio_to_bytes(ref_audio)
+            if audio_bytes is None:
+                raise SystemExit(f"Reference audio file not found: {ref_audio}")
+            byte_audios.append(audio_bytes)
+
+        ref_texts = [read_ref_text(ref_text) for ref_text in ref_texts]
     else:
         byte_audios = []
         ref_texts = []
@@ -161,9 +168,7 @@ if __name__ == "__main__":
     data = {
         "text": args.text,
         "references": [
-            ServeReferenceAudio(
-                audio=ref_audio if ref_audio is not None else b"", text=ref_text
-            )
+            ServeReferenceAudio(audio=ref_audio, text=ref_text)
             for ref_text, ref_audio in zip(ref_texts, byte_audios)
         ],
         "reference_id": idstr,


### PR DESCRIPTION
The `__main__` block of `tools/api_client.py` builds the `references` list in a way that discards bad input without telling the user.

### Two silent failures

**1. A missing reference audio becomes empty audio.** `audio_to_bytes()` returns `None` when the path does not exist, and the result was coerced with `audio=ref_audio if ref_audio is not None else b""`. A typo in `--reference_audio` is therefore sent to the server as an empty reference, which fails later with an unrelated decode error rather than pointing at the bad path.

**2. Mismatched counts are truncated.** `zip(ref_texts, byte_audios)` stops at the shorter sequence. `--reference_audio` and `--reference_text` are separate `nargs="+"` options, so passing three audios and two texts silently drops the third reference.

| input | before | after |
|---|---|---|
| typo in `--reference_audio` | reference sent with `audio=b""` | `Reference audio file not found: typo.wav` |
| 3 audios, 2 texts | 1 reference silently dropped | explicit count-mismatch error |
| 2 audios, 2 texts | 2 references | 2 references (unchanged) |
| no references / `--reference_id` | unchanged | unchanged |

### Fix

Fail fast: report a missing reference audio by path, and require the two options to have matching lengths. With those checks in place the `None` coercion is unreachable, so `references` builds directly from the validated values.

Behavior is unchanged when the arguments are correct, when `--reference_id` is used, and when no references are passed at all.

The repo has no test suite, so I kept this to the behavioral fix rather than introducing pytest as a new dependency.

