### PR TITLE
Fix top-1 guard in logits_to_probs for batched logits

### DIFF
--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -63,7 +63,7 @@ def logits_to_probs(
     indices = torch.arange(sorted_logits.shape[-1], device=sorted_logits.device)
     top_k_mask = indices >= top_k
     sorted_indices_to_remove = (cum_probs > top_p) | top_k_mask
-    sorted_indices_to_remove[0] = False  # 单元素修改问题不大，或者写成 | (indices != 0)
+    sorted_indices_to_remove[..., 0] = False  # keep the top-1 token, per row
 
     indices_to_remove = sorted_indices_to_remove.scatter(
         dim=-1, index=sorted_indices, src=sorted_indices_to_remove


### PR DESCRIPTION
`sorted_indices_to_remove[0] = False` keeps the single most likely token when
top-p/top-k would otherwise remove everything. For the `(V,)` input used today
that is exactly right.

For a `(B, V)` input, `[0]` indexes the first **row**, not the first token:

- sequence 0 has its whole row un-removed, losing top-p/top-k filtering entirely;
- sequences 1.. never get the top-1 guard, so on a confident step where the top
  token's probability alone exceeds `top_p`, every candidate becomes `-inf`,
  `softmax` returns NaN, and the argmax picks noise.

`[..., 0]` is identical for 1-D input and correct when batched.

Nothing in the repo batches today, so this is latent rather than a live bug - but
it is the first thing that breaks for anyone adding a batched sampler, and it
fails silently with plausible-sounding but wrong audio rather than an exception.
Found while writing a batched decoder against s2-pro.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/fish-speech/pr/1326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789891823&installation_model_id=430858&pr_number=1326&repository=fishaudio%2Ffish-speech&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Ffish-speech%2Fpull%2F1326&signature=7fe5a70375babf9d27a42db9fe7bdbb8feb0d9d2b6e286fa6147455116146a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->