### PR TITLE
Size the KV cache to the request rather than model.config.max_seq_len

### DIFF
--- a/fish_speech/models/text2semantic/inference.py
+++ b/fish_speech/models/text2semantic/inference.py
@@ -280,10 +280,18 @@ def generate(
 
     # Critical fix: Only set up cache on first run or when necessary
     if not hasattr(model, "_cache_setup_done") or not model._cache_setup_done:
+        # Size the cache to this request, not to the model maximum. Every decode
+        # step attends over the whole allocation, so a 32768-entry cache makes a
+        # few-hundred-token utterance pay for positions it never uses. Measured on
+        # a gfx1151 APU: decode 0.84 -> 4.23 tok/s, and RTF 4.10 -> 1.96
+        # end-to-end. MAX_SEQ_LEN overrides, and must cover prompt + generated.
+        max_seq_len = int(os.environ.get("MAX_SEQ_LEN", 0)) or min(
+            model.config.max_seq_len, T + max_new_tokens + 64
+        )
         with torch.device(device):
             model.setup_caches(
                 max_batch_size=1,  # Fixed to 1, avoid dynamic changes
-                max_seq_len=model.config.max_seq_len,
+                max_seq_len=max_seq_len,
                 dtype=next(model.parameters()).dtype,
             )
         model._cache_setup_done = True
@@ -758,10 +766,15 @@ def launch_thread_safe_queue(
         model, decode_one_token = init_model(
             checkpoint_path, device, precision, compile=compile
         )
+        # The worker cannot know request lengths ahead of time, so it keeps the
+        # model maximum unless MAX_SEQ_LEN says otherwise. Setting it matters
+        # here: this cache is built first, and generate() skips its own sizing
+        # once _cache_setup_done is set.
         with torch.device(device):
             model.setup_caches(
                 max_batch_size=1,
-                max_seq_len=model.config.max_seq_len,
+                max_seq_len=int(os.environ.get("MAX_SEQ_LEN", 0))
+                or model.config.max_seq_len,
                 dtype=next(model.parameters()).dtype,
             )
         init_event.set()


### PR DESCRIPTION
Every decode step attends over the whole allocated cache, so defaulting
`max_seq_len` to the model maximum (32768) makes a few-hundred-token utterance pay
for positions it never uses.

Isolated decode on a gfx1151 APU (s2-pro bf16):

| max_seq_len | tok/s |
|---|---|
| 32768 | 0.84 |
| 1024 | **4.23** |

End-to-end through the API server with a cloned reference voice: RTF **4.10 ->
1.96**, i.e. a 10-hour audiobook render in 20 h instead of 42 h.

This derives the default from `T + max_new_tokens + 64` and adds a `MAX_SEQ_LEN`
environment variable as an override.

Two things worth reviewing:

- `launch_thread_safe_queue()` builds its cache before `generate()` runs and
  cannot know request lengths, so it keeps the model maximum unless `MAX_SEQ_LEN`
  is set. Without touching that second site the override does nothing on the queue
  path, because `generate()` skips its own sizing once `_cache_setup_done` is set.
- The size must cover prompt **and** generated tokens. 1024 passes a quick test
  and then overflows on a long chunk (1167 prompt tokens + up to 1023 generated),
  hence the `+ 64` margin on top of `T + max_new_tokens`.

Not AMD-specific, though integrated GPUs feel it worst: they share DRAM bandwidth
with the CPU, and bandwidth is exactly what this wastes. Measured on a Radeon
8060S (gfx1151, 128 GB shared LPDDR5 ~256 GB/s), ROCm 7.13.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/fish-speech/pr/1327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789891842&installation_model_id=430858&pr_number=1327&repository=fishaudio%2Ffish-speech&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Ffish-speech%2Fpull%2F1327&signature=07b17e17194beaa605c1df693be10679076cc484756d6a1b189d48edc40a4853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->