### PR TITLE
fix: repair Docker workflow finalization

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - "v*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest-16c64g
@@ -70,6 +74,8 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main'
     steps:
+      - uses: actions/checkout@v4
+
       - name: Push README to Dockerhub
         uses: peter-evans/dockerhub-description@v4
         with:


### PR DESCRIPTION
## Summary

- check out the repository in the update-readme job before the Docker Hub description action reads README.md
- cancel stale Docker image builds for the same ref to avoid redundant work after rapid merges

## Root cause

The four Docker image matrix jobs completed successfully. The separate update-readme job ran in a fresh workspace without a checkout, so peter-evans/dockerhub-description failed with ENOENT for ./README.md.

## Validation

- actionlint v1.7.12 passed after ignoring the repository's existing custom runner label
- uvx --from pre-commit pre-commit run --all-files
- git diff --check

## Post-merge verification

The credentialed Docker Hub README synchronization only runs on pushes to main, so that external step must be confirmed on the first post-merge workflow run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/fish-speech/pr/1328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789980841&installation_model_id=430858&pr_number=1328&repository=fishaudio%2Ffish-speech&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Ffish-speech%2Fpull%2F1328&signature=aa65744a7ca5b990bfd0590583099c769a58a94d7e0a3d2b3d8217754571ac1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->