### PR TITLE
fix: persistent_workers crash at num_workers=0 + warn on silent token truncation

### DIFF
--- a/fish_speech/datasets/semantic.py
+++ b/fish_speech/datasets/semantic.py
@@ -529,6 +529,25 @@ class TextDataCollator:
         max_tokens_length = min(max_tokens_length, self.max_length)
 
         for example in examples:
+            original_length = example[tokens_key].size(1)
+            if original_length > max_tokens_length:
+                # Silent truncation here previously gave no signal that a
+                # training example (text + its full audio-codec token
+                # sequence) had been cut off mid-stream - which can corrupt
+                # training on any dataset whose examples run longer than
+                # sample_data()'s text-only "~20 tokens/sentence" length
+                # estimate once audio tokens are counted too. Surfacing it
+                # lets users notice and raise `max_length` accordingly
+                # instead of silently training on truncated audio.
+                log.warning(
+                    f"Truncating example from {original_length} to "
+                    f"{max_tokens_length} tokens (max_length={self.max_length}) "
+                    "- the training example (including its audio-codec "
+                    "tokens) is longer than max_length. Consider raising "
+                    "max_length if this happens often, to avoid training on "
+                    "truncated audio."
+                )
+
             _tokens = example[tokens_key][:, :max_tokens_length]
             _labels = example[labels_key][:, :max_tokens_length]
             _attention_mask = torch.ones((max_tokens_length,), dtype=torch.bool)
@@ -598,7 +617,12 @@ class SemanticDataModule(LightningDataModule):
             batch_size=self.batch_size,
             collate_fn=TextDataCollator(self.tokenizer, self.max_length),
             num_workers=self.num_workers,
-            persistent_workers=True,
+            # persistent_workers=True is invalid when num_workers=0 (torch
+            # raises "persistent_workers option needs num_workers > 0")
+            # PyTorch's own DataLoader constructor requires this to be
+            # conditional - num_workers=0 is a legitimate choice for small
+            # datasets/debugging, so this shouldn't need to hard-fail.
+            persistent_workers=self.num_workers > 0,
         )
 
     def val_dataloader(self):
@@ -607,7 +631,7 @@ class SemanticDataModule(LightningDataModule):
             batch_size=self.batch_size,
             collate_fn=TextDataCollator(self.tokenizer, self.max_length),
             num_workers=self.num_workers,
-            persistent_workers=True,
+            persistent_workers=self.num_workers > 0,
         )
 
 


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

Fix BUG (two small, independent fixes in `fish_speech/datasets/semantic.py`).

**Is this pull request related to any issue? If yes, please link the issue.**

Not filed as a separate issue, but related in spirit to #1163 (pretrained weights being silently destroyed) - this PR is about a different pair of *silent* failure modes in the dataset/dataloader path that we hit while LoRA fine-tuning `text2semantic` on a small (~1,000 clip) custom dataset.

### 1. `persistent_workers=True` hardcoded, crashes at `num_workers=0`

`SemanticDataModule.train_dataloader()`/`val_dataloader()` hardcode `persistent_workers=True` regardless of `num_workers`. PyTorch's `DataLoader` raises immediately if `persistent_workers=True` is passed with `num_workers=0`:

```
ValueError: persistent_workers option needs num_workers > 0
```

`num_workers=0` is a legitimate, common choice for small datasets (few shards) or when debugging - the finetune docs' own recipe doesn't forbid it. Made `persistent_workers` conditional on `num_workers > 0`, matching the flag's actual precondition.

### 2. Silent truncation with no warning in `TextDataCollator.batchify()`

```python
_tokens = example[tokens_key][:, :max_tokens_length]
```

This slices any example longer than `max_length` with zero log/warning. Since a packed example's token sequence includes the *full audio-codec token stream* for its sentence(s) - not just text - and `AutoTextSemanticInstructionIterableDataset.sample_data()`'s `num_samples = self.max_length // 20` heuristic only estimates length from **text** tokens (`# estimate that each sample is at least 20 tokens`), it's easy to end up with examples that exceed `max_length` once audio tokens are counted, and get silently truncated mid-audio - corrupting the training target with no indication anything went wrong.

Added a `log.warning(...)` when this truncation actually fires, so users get a clear signal to raise `max_length` (or reduce `num_samples`) instead of unknowingly training on truncated audio. Purely additive/observability - no change to actual training behavior.

### Testing

Both fixes verified against a real fine-tuning run (LoRA, `text2semantic_finetune`, ~1,000 clip custom dataset, `num_workers=0`, H100): the first fix is required just to get training running at `num_workers=0` at all; the second warning was verified to correctly fire on examples we confirmed (by manual inspection) were being truncated mid-audio under the default heuristic.

— Submitted by [SynthioLabs](https://github.com/SynthioLabsLtd)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/fish-speech/pr/1329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790420765&installation_model_id=430858&pr_number=1329&repository=fishaudio%2Ffish-speech&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Ffish-speech%2Fpull%2F1329&signature=364666d72d0f34c1bf6c7a485c77de2284ca4601d244433b5aa18b7ca45fa529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
